### PR TITLE
Fix stokes passed as integer string to imsubimage in 4D mosaic path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Large-cube memory issues with channel-wise processing (#323)
 - Fixed TP crash when different atmospheric correction types are used (#343).
 - Calculation of additional number of channels in regrid mstransform call (#344).
+- Fix stokes passed as integer string to imsubimage in 4D mosaic path (#349).
 
 ### Dependencies
 - Bump actions/upload-artifact from 6 to 7 (#313).

--- a/phangsPipeline/casaMosaicRoutines.py
+++ b/phangsPipeline/casaMosaicRoutines.py
@@ -1207,7 +1207,11 @@ def mosaic_aligned_data(
                 nchan = cube_shape[2]
                 total = nstokes * nchan
                 logger.info(f'Processing {nstokes} Stokes x {nchan} channels = {total} planes')
-                
+
+                csys_tmp = myia_sum.coordsys()
+                stokes_labels = csys_tmp.stokes()
+                csys_tmp.done()
+
                 counter = 0
                 for istokes in range(nstokes):
                     for ichan in range(nchan):
@@ -1222,7 +1226,7 @@ def mosaic_aligned_data(
                         for idx, im in enumerate(local_imlist):
                             temp_chan = f'temp_ch{ichan}_st{istokes}_img{idx}'
                             casaStuff.imsubimage(imagename=im, outfile=temp_chan,
-                                               chans=str(ichan), stokes=str(istokes), 
+                                               chans=str(ichan), stokes=stokes_labels[istokes],
                                                dropdeg=False)
                             temp_chan_images.append(temp_chan)
                         


### PR DESCRIPTION
In the channel-by-channel ndim==4 path of mosaic_aligned_data, imsubimage was being called with stokes='0' (an integer index as a string), but it requires a polarization label like 'I'. Fixed by reading the stokes labels from the coordinate system of myia_sum, which is already open at that point.