### PR TITLE
Import recipe_phangs_flat_mask in handlerDerived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed TP crash when different atmospheric correction types are used (#343).
 - Calculation of additional number of channels in regrid mstransform call (#344).
 - Fix stokes passed as integer string to imsubimage in 4D mosaic path (#349).
+- Import recipe_phangs_flat_mask in handlerDerived (#357).
 
 ### Dependencies
 - Bump actions/upload-artifact from 6 to 7 (#313).

--- a/phangsPipeline/handlerDerived.py
+++ b/phangsPipeline/handlerDerived.py
@@ -29,7 +29,7 @@ import numpy as np
 from . import handlerTemplate
 from . import utilsFilenames
 from .scConvolution import smooth_cube
-from .scMaskingRoutines import recipe_phangs_strict_mask, recipe_phangs_broad_mask
+from .scMaskingRoutines import recipe_phangs_strict_mask, recipe_phangs_broad_mask, recipe_phangs_flat_mask
 from .scMoments import moment_generator
 from .scNoiseRoutines import recipe_phangs_noise
 from .scStackingRoutines import recipe_phangs_vfield, recipe_shuffle_cube


### PR DESCRIPTION
recipe_phangs_flat_mask is called in DerivedHandler but was missing from the scMaskingRoutines import, which raises NameError when those code paths run. This adds it to the import list. 