### PR TITLE
Added spectral-cube equivalents for postprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added .codecov.yml to configure codecov (#364).
 - Add more control over multiscale clean scales (#362).
 - Add tests for utilsLines, and tidy up formatting (#363).
+- Added spectral-cube equivalent routines for postprocessing (#371).
 
 ### Changed
 

--- a/docs/docs_phangsPipeline/handlers/PostProcessHandler.rst
+++ b/docs/docs_phangsPipeline/handlers/PostProcessHandler.rst
@@ -7,5 +7,12 @@ a single big class (the PostProcessHandler). This needs to be attached
 to a keyHandler to access the target, product, and configuration
 keys.
 
+There are two options for how postprocessing is handled. The default
+uses CASA functions, which is the default but can be slow (especially
+for large cubes). The other option is to use the faster spectral-cube
+routines, which are faster and give comparable results, but are less
+well-tested. To change between these, in the ``loop_postprocess`` call,
+set ``postprocessing_method='casa'`` or ``postprocessing_method='spectralcube'``.
+
 .. autofunction:: phangsPipeline.PostProcessHandler.loop_postprocess
     :noindex:

--- a/phangsPipeline/handlerPostprocess.py
+++ b/phangsPipeline/handlerPostprocess.py
@@ -26,6 +26,33 @@ if casa_enabled:
     logger.debug('casa_enabled = True')
 else:
     logger.debug('casa_enabled = False')
+    
+ALLOWED_POSTPROCESSING_METHODS = [
+    "casa",
+    "spectralcube",
+]
+
+def check_files_exist(
+    f,
+    postprocessing_method="casa",
+):
+    """Check if files exist, potentially modifying by postprocess method
+
+    Args:
+        f (str): filename
+        postprocessing_method (str, optional): Postprocessing method.
+            Should be one of "casa", "spectralcube". Defaults to "casa".
+    """
+
+    if postprocessing_method == "spectralcube":
+        f += ".fits"
+
+    files_exist = True
+    if not os.path.exists(f):
+        logger.warning(f"Missing {f}")
+        files_exist = False
+
+    return files_exist
 
 if casa_enabled:
 
@@ -33,6 +60,9 @@ if casa_enabled:
     from . import casaFeatherRoutines as cfr
     from . import casaMosaicRoutines as cmr
     from . import handlerTemplate
+    from . import scCubeRoutines as scr
+    from . import scFeatherRoutines as sfr
+    from . import scMosaicRoutines as smr
     from . import utilsFilenames
     from . import utilsResolutions
     from .clean_call import CleanCall
@@ -336,21 +366,24 @@ if casa_enabled:
         # region "Tasks" : Individual postprocessing steps
 
         def task_stage_interf_data(
-                self,
-                target=None,
-                product=None,
-                config=None,
-                imaging_method='tclean',
-                extra_ext_in='',
-                extra_ext_out='',
-                check_files=True,
-                trim_coarse_beam_edge_channels=False,
+            self,
+            target=None,
+            product=None,
+            config=None,
+            imaging_method: str = "tclean",
+            postprocessing_method: str = "casa",
+            extra_ext_in="",
+            extra_ext_out="",
+            check_files=True,
         ):
             """
             For one target, product, config combination copy the
             interferometric cube and primary beam file to the working
             postprocessing directory.
             """
+
+            if postprocessing_method not in ALLOWED_POSTPROCESSING_METHODS:
+                raise ValueError(f"Postprocessing method must be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             # Generate file names
 
@@ -370,8 +403,8 @@ if casa_enabled:
 
                 # Check input file existence
                 if check_files:
-                    if not (os.path.isdir(indir + infile)):
-                        logger.warning("Missing " + indir + infile)
+                    files_exist = check_files_exist(indir + infile)
+                    if not files_exist:
                         continue
 
                 logger.info("")
@@ -385,26 +418,31 @@ if casa_enabled:
                 # Move the cubes to the postprocess directory, trimming along the way
                 # (though not rebinning)
                 if not self._dry_run:
-                    os.system('rm -rf ' + outdir + outfile)
-                    os.system('rm -rf ' + outdir + outfile + ".temp")
 
-                    ccr.trim_cube(
-                        infile=indir + infile,
-                        outfile=outdir + outfile,
-                        overwrite=True,
-                        inplace=False,
-                        pad=1,
-                        rebin=False,
-                    )
-
-            # in case of merged datasets with non-identical frequency setups imaged with per-plane beam,
-            # some edge channels will have much coarser beam, we trim these edge channels here.
-            if trim_coarse_beam_edge_channels:
-                ccr.trim_coarse_beam_edge_channels(
-                    infile=outdir + fname_dict_out['orig'],
-                    inpbfile=outdir + fname_dict_out['pb'],
-                    inplace=True,
-                )
+                    if postprocessing_method == "casa":
+                        os.system("rm -rf " + outdir + outfile)
+                        os.system("rm -rf " + outdir + outfile + ".temp")
+                        
+                        ccr.trim_cube(
+                            infile=indir + infile,
+                            outfile=outdir + outfile,
+                            overwrite=True,
+                            inplace=False,
+                            pad=1,
+                            rebin=False,
+                        )
+                    elif postprocessing_method == "spectralcube":
+                        os.system(f"rm -rf {outdir}{outfile}.fits")
+                        
+                        scr.trim_cube(
+                            infile=f"{indir}{infile}",
+                            outfile=f"{outdir}{outfile}.fits",
+                            overwrite=True,
+                            pad=1,
+                            rebin=False,
+                        )
+                    else:
+                        raise ValueError(f"postprocessing_method must be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             return ()
 
@@ -414,6 +452,7 @@ if casa_enabled:
                 product=None,
                 config=None,
                 imaging_method='tclean',
+                postprocessing_method="casa",
                 in_tag='orig',
                 out_tag='pbcorr',
                 extra_ext_in='',
@@ -424,6 +463,9 @@ if casa_enabled:
             For one target, product, config combination primary beam
             correct the interferometer data.
             """
+
+            if postprocessing_method not in ALLOWED_POSTPROCESSING_METHODS:
+                raise ValueError(f"Postprocessing method must be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             # Generate file names
 
@@ -446,11 +488,17 @@ if casa_enabled:
             # Check input file existence
 
             if check_files:
-                if not (os.path.isdir(indir + infile)):
-                    logger.warning("Missing " + indir + infile)
+                files_exist = check_files_exist(
+                    indir + infile,
+                    postprocessing_method=postprocessing_method,
+                )
+                if not files_exist:
                     return ()
-                if not (os.path.isdir(indir + pbfile)):
-                    logger.warning("Missing " + indir + pbfile)
+                files_exist = check_files_exist(
+                    indir + pbfile,
+                    postprocessing_method=postprocessing_method,
+                )
+                if not files_exist:
                     return ()
 
             # Apply the primary beam correction to the data.
@@ -462,18 +510,30 @@ if casa_enabled:
             logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%")
             logger.info("")
 
-            logger.info("Using ccr.primary_beam_correct")
+            logger.info("Using primary_beam_correct")
             logger.info("Correcting to " + outfile)
             logger.info("Correcting from " + infile)
             logger.info("Correcting using " + pbfile)
 
             if not self._dry_run:
-                ccr.primary_beam_correct(
-                    infile=indir + infile,
-                    outfile=outdir + outfile,
-                    pbfile=indir + pbfile,
-                    cutoff=cutoff,
-                    overwrite=True)
+                if postprocessing_method == "casa":
+                    ccr.primary_beam_correct(
+                        infile=indir + infile,
+                        outfile=outdir + outfile,
+                        pbfile=indir + pbfile,
+                        cutoff=cutoff,
+                        overwrite=True,
+                    )
+                elif postprocessing_method == "spectralcube":
+                    scr.primary_beam_correct(
+                        infile=f"{indir}{infile}.fits",
+                        outfile=f"{outdir}{outfile}.fits",
+                        pbfile=f"{indir}{pbfile}.fits",
+                        cutoff=cutoff,
+                        overwrite=True,
+                    )
+                else:
+                    raise ValueError(f"postprocessing_method must be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             return ()
 
@@ -483,6 +543,7 @@ if casa_enabled:
                 product=None,
                 config=None,
                 imaging_method='tclean',
+                postprocessing_method="casa",
                 in_tag='pbcorr',
                 out_tag='pbcorr_round',
                 extra_ext_in='',
@@ -496,6 +557,9 @@ if casa_enabled:
             this task can also be used to convolve data to a fixed (round)
             angular resolution.
             """
+            
+            if postprocessing_method not in ALLOWED_POSTPROCESSING_METHODS:
+                raise ValueError(f"postprocessing_method must be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             # Generate file names
 
@@ -512,8 +576,10 @@ if casa_enabled:
             # Check input file existence
 
             if check_files:
-                if not (os.path.isdir(indir + infile)):
-                    logger.warning("Missing " + infile)
+                files_exist = check_files_exist(indir+infile,
+                                                postprocessing_method=postprocessing_method,
+                                                )
+                if not files_exist:
                     return ()
 
             # Convolve the data to have a round beam.
@@ -525,18 +591,28 @@ if casa_enabled:
             logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%")
             logger.info("")
 
-            logger.info("Using ccr.convolve_to_round_beam")
+            logger.info("Using convolve_to_round_beam")
             logger.info("Convolving from " + infile)
             logger.info("Convolving to " + outfile)
             if force_beam_as is not None:
                 logger.info("Forcing beam to " + str(force_beam_as))
 
             if not self._dry_run:
-                ccr.convolve_to_round_beam(
-                    infile=indir + infile,
-                    outfile=outdir + outfile,
-                    force_beam=force_beam_as,
-                    overwrite=True)
+                if postprocessing_method == "casa":
+                    ccr.convolve_to_round_beam(
+                        infile=indir + infile,
+                        outfile=outdir + outfile,
+                        force_beam=force_beam_as,
+                        overwrite=True,
+                    )
+                elif postprocessing_method == "spectralcube":
+                    scr.convolve_to_round_beam(
+                        infile=f"{indir}{infile}.fits",
+                        outfile=f"{outdir}{outfile}.fits",
+                        force_beam=force_beam_as,
+                        overwrite=True,
+                    )
+            
 
             return ()
 
@@ -545,6 +621,7 @@ if casa_enabled:
                 target=None,
                 product=None,
                 config=None,
+                postprocessing_method="casa",
                 template_tag='pbcorr_round',
                 out_tag='prepped_sd',
                 extra_ext_in='',
@@ -555,6 +632,9 @@ if casa_enabled:
             For one target, product, config combination, copy the single
             dish data and align it to the interferometric grid.
             """
+            
+            if postprocessing_method not in ALLOWED_POSTPROCESSING_METHODS:
+                raise ValueError(f"postprocessing_method must be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             # Generate file names
 
@@ -573,12 +653,15 @@ if casa_enabled:
             # Check input file existence
 
             if check_files:
-                if (not (os.path.isdir(indir + infile))) and \
-                        (not (os.path.isfile(indir + infile))):
-                    logger.warning("Missing " + infile)
+
+                files_exist = check_files_exist(indir+infile)
+                if not files_exist:
                     return ()
-                if not (os.path.isdir(tempdir + template)):
-                    logger.warning("Missing " + tempdir + template)
+                
+                files_exist = check_files_exist(tempdir+template,
+                                                postprocessing_method=postprocessing_method,
+                                                )
+                if not files_exist:
                     return ()
 
             # Stage the singledish data for feathering
@@ -590,37 +673,51 @@ if casa_enabled:
             logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%")
             logger.info("")
 
-            logger.info("Using cfr.prep_sd_for_feather.")
+            logger.info("Using prep_sd_for_feather.")
             logger.info("Prepping " + outfile)
             logger.info("Original file " + infile)
             logger.info("Using interferometric template " + template)
 
             if not self._dry_run:
-                cfr.prep_sd_for_feather(
-                    sdfile_in=indir + infile,
-                    sdfile_out=outdir + outfile,
-                    interf_file=tempdir + template,
-                    do_import=True,
-                    do_align=True,
-                    do_checkunits=True,
-                    overwrite=True)
+                
+                if postprocessing_method == "casa":
+                    cfr.prep_sd_for_feather(
+                        sdfile_in=indir + infile,
+                        sdfile_out=outdir + outfile,
+                        interf_file=tempdir + template,
+                        do_import=True,
+                        do_align=True,
+                        do_checkunits=True,
+                        overwrite=True)
+                elif postprocessing_method == "spectralcube":
+                    sfr.prep_sd_for_feather(
+                        sdfile_in=f"{indir}{infile}",
+                        sdfile_out=f"{outdir}{outfile}.fits",
+                        interf_file=f"{tempdir}{template}.fits",
+                        do_align=True,
+                        do_checkunits=True,
+                        overwrite=True,
+                    )
+                else:
+                    raise ValueError(f"postprocessing_method must be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             return ()
 
         def task_make_interf_weight(
-                self,
-                target=None,
-                product=None,
-                config=None,
-                imaging_method='tclean',
-                image_tag='pbcorr_round',
-                in_tag='pb',
-                input_type='pb',
-                scale_by_noise=True,
-                out_tag='weight',
-                extra_ext_in='',
-                extra_ext_out='',
-                check_files=True,
+            self,
+            target=None,
+            product=None,
+            config=None,
+            imaging_method="tclean",
+            postprocessing_method: str = "casa",
+            image_tag="pbcorr_round",
+            in_tag="pb",
+            input_type="pb",
+            scale_by_noise=True,
+            out_tag="weight",
+            extra_ext_in="",
+            extra_ext_out="",
+            check_files=True,
         ):
             """
             For one target, product, config combination, make a 'weight'
@@ -628,6 +725,9 @@ if casa_enabled:
             overlapping cubes. This task targets interferometric dish
             data.
             """
+
+            if postprocessing_method not in ALLOWED_POSTPROCESSING_METHODS:
+                raise ValueError(f"postprocessing_method must be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             # Generate file names
 
@@ -645,11 +745,16 @@ if casa_enabled:
             # Check input file existence
 
             if check_files:
-                if not (os.path.isdir(indir + infile)):
-                    logger.warning("Missing " + infile)
+                files_exist = check_files_exist(indir+infile,
+                                                postprocessing_method=postprocessing_method,
+                                                )
+                if not files_exist:
                     return ()
-                if not (os.path.isdir(indir + image_file)):
-                    logger.warning("Missing " + image_file)
+
+                files_exist = check_files_exist(indir+image_file,
+                                                postprocessing_method=postprocessing_method,
+                                                )
+                if not files_exist:
                     return ()
 
             # Create a weight image for use linear mosaicking targets that
@@ -662,19 +767,33 @@ if casa_enabled:
             logger.info("&%&%&%&%&%&%&%&%&%&%&%&")
             logger.info("")
 
-            logger.info("Using cmr.generate_weight_file.")
+            logger.info("Using generate_weight_file.")
             logger.info("Making weight file " + outfile)
             logger.info("Based off of primary beam file " + infile)
             logger.info("Measuring noise from file " + image_file)
 
             if not self._dry_run:
-                cmr.generate_weight_file(
-                    image_file=indir + image_file,
-                    input_file=indir + infile,
-                    input_type=input_type,
-                    outfile=indir + outfile,
-                    scale_by_noise=scale_by_noise,
-                    overwrite=True)
+                
+                if postprocessing_method == "casa":
+                    cmr.generate_weight_file(
+                        image_file=indir + image_file,
+                        input_file=indir + infile,
+                        input_type=input_type,
+                        outfile=indir + outfile,
+                        scale_by_noise=scale_by_noise,
+                        overwrite=True,
+                    )
+                elif postprocessing_method == "spectralcube":
+                    smr.generate_weight_file(
+                        image_file=f"{indir}{image_file}.fits",
+                        input_file=f"{indir}{infile}.fits",
+                        input_type=input_type,
+                        outfile=f"{indir}{outfile}.fits",
+                        scale_by_noise=scale_by_noise,
+                        overwrite=True,
+                    )
+                else:
+                    raise ValueError(f"postprocessing_method must be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             return ()
 
@@ -683,6 +802,7 @@ if casa_enabled:
                 target=None,
                 product=None,
                 config=None,
+                postprocessing_method="casa",
                 image_tag='prepped_sd',
                 out_tag='sd_weight',
                 extra_ext_in='',
@@ -694,6 +814,9 @@ if casa_enabled:
             image for use in linearly mosaicking the cube with other,
             overlapping cubes. This task targets single dish data.
             """
+            
+            if postprocessing_method not in ALLOWED_POSTPROCESSING_METHODS:
+                raise ValueError(f"postprocessing_method must be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             # Generate file names
 
@@ -710,8 +833,10 @@ if casa_enabled:
             # Check input file existence
 
             if check_files:
-                if not (os.path.isdir(indir + image_file)):
-                    logger.warning("Missing " + image_file)
+                files_exist = check_files_exist(indir+image_file,
+                                                postprocessing_method=postprocessing_method,
+                                                )
+                if not files_exist:
                     return ()
 
             # Make a weight file for single dish targets that
@@ -724,18 +849,31 @@ if casa_enabled:
             logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&")
             logger.info("")
 
-            logger.info("Using cmr.generate_weight_file.")
+            logger.info("Using generate_weight_file.")
             logger.info("Making weight file " + outfile)
             logger.info("Measuring noise from file " + image_file)
 
             if not self._dry_run:
-                cmr.generate_weight_file(
-                    image_file=indir + image_file,
-                    input_value=1.0,
-                    input_type='weight',
-                    outfile=indir + outfile,
-                    scale_by_noise=True,
-                    overwrite=True)
+                if postprocessing_method == "casa":
+                    cmr.generate_weight_file(
+                        image_file=indir + image_file,
+                        input_value=1.0,
+                        input_type='weight',
+                        outfile=indir + outfile,
+                        scale_by_noise=True,
+                        overwrite=True,
+                    )
+                elif postprocessing_method == "spectralcube":
+                    smr.generate_weight_file(
+                        image_file=f"{indir}{image_file}.fits",
+                        input_value=1.0,
+                        input_type="weight",
+                        outfile=f"{indir}{outfile}.fits",
+                        scale_by_noise=True,
+                        overwrite=True,
+                    )
+                else:
+                    raise ValueError(f"postprocessing_method must be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             return ()
 
@@ -753,6 +891,7 @@ if casa_enabled:
                 apod_ext='pb',
                 copy_weights=True,
                 check_files=True,
+                postprocessing_method="casa",
         ):
             """
             For one target, product, config combination, feather together
@@ -764,6 +903,9 @@ if casa_enabled:
             from the interferometric side to become the weights for the
             new feathered data.
             """
+
+            if postprocessing_method not in ALLOWED_POSTPROCESSING_METHODS:
+                raise ValueError(f"Postprocessing method must be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             # Generate file names
 
@@ -803,7 +945,7 @@ if casa_enabled:
             logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%")
             logger.info("")
 
-            logger.info("Using cfr.feather_two_cubes.")
+            logger.info("Using feather_two_cubes.")
             logger.info("Feathering " + outfile)
             logger.info("Feathering interferometric data " + interf_file)
             logger.info("Feathering single dish data " + sd_file)
@@ -812,46 +954,55 @@ if casa_enabled:
             # associated with it. Run the method that the
             # user has selected.
 
+            # Switches between apodization and not
+            do_apodize = False
+            apod_file = None
+            apod_cutoff = -1.0
+            
             if apodize:
-
                 apod_file = fname_dict_in[apod_ext]
-
                 logger.info("Apodizing using file " + apod_file)
+                apod_file = f"{indir}{apod_file}"
+                do_apodize = True
+                apod_cutoff = 0.0
 
-                if not self._dry_run:
+            if not self._dry_run:
+                if postprocessing_method == "casa":
                     cfr.feather_two_cubes(
                         interf_file=indir + interf_file,
                         sd_file=indir + sd_file,
                         out_file=outdir + outfile,
                         do_blank=True,
-                        do_apodize=True,
-                        apod_file=indir + apod_file,
-                        apod_cutoff=0.0,
-                        overwrite=True)
-
-            else:
-
-                if not self._dry_run:
-                    cfr.feather_two_cubes(
-                        interf_file=indir + interf_file,
-                        sd_file=indir + sd_file,
-                        out_file=outdir + outfile,
-                        do_blank=True,
-                        do_apodize=False,
-                        apod_file=None,
-                        apod_cutoff=-1.0,
-                        overwrite=True)
+                        do_apodize=do_apodize,
+                        apod_file=apod_file,
+                        apod_cutoff=apod_cutoff,
+                        overwrite=True,
+                    )
+                elif postprocessing_method == "spectralcube":
+                    sfr.feather_two_cubes(
+                        interf_file=f"{indir}{interf_file}.fits",
+                        sd_file=f"{indir}{sd_file}.fits",
+                        out_file=f"{outdir}{outfile}.fits",
+                        do_apodize=do_apodize,
+                        apod_file=apod_file,
+                        apod_cutoff=apod_cutoff,
+                        overwrite=True,
+                    )
+                else:
+                    raise ValueError(f"postprocessing_method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             if copy_weights:
 
-                interf_weight_exists = False
                 interf_weight_file = fname_dict_in['weight']
-                if os.path.isdir(indir + interf_weight_file):
-                    interf_weight_exists = True
-                else:
+
+                interf_weight_exists = check_files_exist(indir + interf_weight_file,
+                                                         postprocessing_method=postprocessing_method,
+                                                         )
+
+                if not interf_weight_exists:
                     logger.info("Interferometric weight file not found " + interf_weight_file)
 
-                if interf_weight_exists:
+                else:
                     logger.info("")
                     logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%")
                     logger.info("Copying weights for:")
@@ -864,17 +1015,26 @@ if casa_enabled:
                     logger.info("Copying from " + interf_weight_file)
                     logger.info("Copying to " + out_weight_file)
                     if not self._dry_run:
-                        ccr.copy_importfits(infile=indir + interf_weight_file,
-                                            outfile=outdir + out_weight_file,
-                                            overwrite=True,
-                                            )
+
+                        if postprocessing_method == "casa":
+                            ccr.copy_importfits(infile=indir + interf_weight_file,
+                                                outfile=outdir + out_weight_file,
+                                                overwrite=True,
+                                                )
+                        elif postprocessing_method == "spectralcube":
+                            os.system(f"cp -rf {indir}{interf_weight_file}.fits {outdir}{out_weight_file}.fits")
+                        else:
+                            raise ValueError(f"postprocessing_method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
+
             return ()
 
         def task_rename_sdintimaging(self,
                                      target=None,
                                      product=None,
                                      config=None,
-                                     imaging_method='sdintimaging'):
+                                     imaging_method='sdintimaging',
+                                     postprocessing_method="casa",
+                                     ):
 
             if target is None:
                 logger.warning('Missing target')
@@ -889,6 +1049,9 @@ if casa_enabled:
             if imaging_method != 'sdintimaging':
                 logger.warning('This should only be run for sdintimaging')
                 return
+            
+            if postprocessing_method not in ALLOWED_POSTPROCESSING_METHODS:
+                raise ValueError(f"postprocessing_method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             fname_dict_in = self._fname_dict(target=target, product=product, config=config,
                                              imaging_method=imaging_method)
@@ -937,11 +1100,35 @@ if casa_enabled:
                     continue
 
                 file_name = outdir + item
+                if postprocessing_method == "spectralcube":
+                    file_name += ".fits"
+                
                 if os.path.exists(file_name):
                     new_file_name = outdir + fname_dict_out[key]
+
+                    if postprocessing_method == "spectralcube":
+                        new_file_name += ".fits"
+                    
                     command = 'mv -f %s %s' % (file_name, new_file_name)
                     os.system('rm -rf %s' % new_file_name)
                     os.system(command)
+
+                # Rename the image_slice mosaic files
+                slice_file = outdir + item + "_slice.txt"
+                if os.path.exists(slice_file):
+                    new_slice_file = outdir + fname_dict_out[key] + "_slice.txt"
+                    os.system('rm -f %s' % new_slice_file)
+                    os.system('mv -f %s %s' % (slice_file, new_slice_file))
+
+            # Rename the linear mosaic template headers
+            for template_suffix in ["flux", "weight", "mask"]:
+                template_in = outdir + "%s_%s_%s_linmos_template_%s.txt" % (
+                    target, config, product, template_suffix)
+                template_out = outdir + "%s_%s_%s_linmos_template_%s.txt" % (
+                    target, feather_config, product, template_suffix)
+                if os.path.exists(template_in):
+                    os.system('rm -f %s' % template_out)
+                    os.system('mv -f %s %s' % (template_in, template_out))
 
             return
 
@@ -951,6 +1138,7 @@ if casa_enabled:
                 product=None,
                 config=None,
                 imaging_method='tclean',
+                postprocessing_method="casa",
                 in_tag='pbcorr_round',
                 out_tag='pbcorr_trimmed',
                 do_trimrind=True,
@@ -966,6 +1154,9 @@ if casa_enabled:
             to the smallest reasonable volume. Also align the primary beam
             file out onto this grid.
             """
+
+            if postprocessing_method not in ALLOWED_POSTPROCESSING_METHODS:
+                raise ValueError(f"postprocessing_method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             # Generate file names
 
@@ -985,8 +1176,10 @@ if casa_enabled:
             # Check input file existence
 
             if check_files:
-                if not (os.path.isdir(indir + infile)):
-                    logger.warning("Missing " + infile)
+                files_exist = check_files_exist(indir + infile,
+                                                postprocessing_method=postprocessing_method,
+                                                )
+                if not files_exist:
                     return ()
 
             # Compress, reducing cube volume.
@@ -998,53 +1191,88 @@ if casa_enabled:
             logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%")
             logger.info("")
 
-            logger.info("Producing " + outfile + " using ccr.trim_cube.")
+            logger.info("Producing " + outfile + " using trim_cube.")
             logger.info("Trimming from original file " + infile)
 
             if not self._dry_run:
-                ccr.trim_cube(
-                    infile=indir + infile,
-                    outfile=outdir + outfile,
-                    overwrite=True,
-                    inplace=False,
-                    min_pixperbeam=3,
-                    pad=1)
+                if postprocessing_method == "casa":
+                    ccr.trim_cube(
+                        infile=indir + infile,
+                        outfile=outdir + outfile,
+                        overwrite=True,
+                        inplace=False,
+                        min_pixperbeam=3,
+                        pad=1,
+                    )
+                elif postprocessing_method == "spectralcube":
+                    scr.trim_cube(
+                        infile=f"{indir}{infile}.fits",
+                        outfile=f"{outdir}{outfile}.fits",
+                        overwrite=True,
+                        min_pixperbeam=3,
+                        pad=1,
+                    )
+                else:
+                    raise ValueError(f"postprocessing_method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
                 if do_trimrind:
-                    ccr.trim_rind(
-                        infile=outdir + outfile,
-                        inplace=True,
-                        pixels=1)
+                    if postprocessing_method == "casa":
+                        ccr.trim_rind(
+                            infile=outdir + outfile,
+                            inplace=True,
+                            pixels=1,
+                        )
+                    elif postprocessing_method == "spectralcube":
+                        scr.trim_rind(
+                            infile=f"{outdir}{outfile}.fits",
+                            pixels=1,
+                        )
+                    else:
+                        raise ValueError(f"postprocessing_method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
-            if do_pb_too is False:
+            if not do_pb_too:
                 return ()
 
             if check_files:
-                if not (os.path.isdir(indir + infile_pb)):
-                    logger.warning("Missing " + infile_pb)
+                files_exist = check_files_exist(indir + infile,
+                                                postprocessing_method=postprocessing_method,
+                                                )
+                if not files_exist:
                     return ()
 
             template = fname_dict_out['pbcorr_trimmed']
 
             if check_files:
-                if not (os.path.isdir(outdir + template)):
-                    logger.warning("Missing " + template)
+                files_exist = check_files_exist(outdir + template, 
+                                                postprocessing_method=postprocessing_method,
+                                                )
+                if not files_exist:
                     return ()
 
             logger.info("Aligning primary beam image to new astrometry")
-            logger.info("Using ccr.align_to_target.")
+            logger.info("Using align_to_target.")
             logger.info("Aligning original file " + infile_pb)
             logger.info("Aligning to produce output file " + outfile_pb)
             logger.info("Aligning to template " + template)
 
             if not self._dry_run:
-                ccr.align_to_target(
-                    infile=indir + infile_pb,
-                    outfile=outdir + outfile_pb,
-                    template=outdir + template,
-                    interpolation='cubic',
-                    overwrite=True,
-                )
+                if postprocessing_method == "casa":
+                    ccr.align_to_target(
+                        infile=indir + infile_pb,
+                        outfile=outdir + outfile_pb,
+                        template=outdir + template,
+                        interpolation='cubic',
+                        overwrite=True,
+                    )
+                elif postprocessing_method == "spectralcube":
+                    scr.align_to_target(
+                        infile=f"{indir}{infile_pb}.fits",
+                        outfile=f"{outdir}{outfile_pb}.fits",
+                        template=f"{outdir}{template}.fits",
+                        overwrite=True,
+                    )
+                else:
+                    raise ValueError(f"postprocessing method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             return ()
 
@@ -1054,6 +1282,7 @@ if casa_enabled:
                 product=None,
                 config=None,
                 imaging_method='tclean',
+                postprocessing_method="casa",
                 in_tag='pbcorr_trimmed',
                 out_tag='pbcorr_trimmed_k',
                 extra_ext_in='',
@@ -1064,6 +1293,9 @@ if casa_enabled:
             For one target, config, product combination convert the units
             from Jy/beam to Kelvin.
             """
+            
+            if postprocessing_method not in ALLOWED_POSTPROCESSING_METHODS:
+                raise ValueError(f"postprocessing_method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             # Generate file names
 
@@ -1080,8 +1312,10 @@ if casa_enabled:
             # Check input file existence
 
             if check_files:
-                if not (os.path.isdir(indir + infile)):
-                    logger.warning("Missing " + infile)
+                files_exist = check_files_exist(indir + infile,
+                                                postprocessing_method=postprocessing_method,
+                                                )
+                if not files_exist:
                     return ()
 
             # Change units from Jy/beam to Kelvin.
@@ -1093,17 +1327,27 @@ if casa_enabled:
             logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%")
             logger.info("")
 
-            logger.info("Using ccr.convert_jytok")
+            logger.info("Using convert_jytok")
             logger.info("Creating " + outfile)
             logger.info("Converting from original file " + infile)
 
             if not self._dry_run:
-                ccr.convert_jytok(
-                    infile=indir + infile,
-                    outfile=outdir + outfile,
-                    overwrite=True,
-                    inplace=False,
-                )
+                if postprocessing_method == "casa":
+                    ccr.convert_jytok(
+                        infile=indir + infile,
+                        outfile=outdir + outfile,
+                        overwrite=True,
+                        inplace=False,
+                    )
+                elif postprocessing_method == "spectralcube":
+                    scr.convert_units(
+                        infile=f"{indir}{infile}.fits",
+                        outfile=f"{outdir}{outfile}.fits",
+                        units="K",
+                        overwrite=True,
+                    )
+                else:
+                    raise ValueError(f"postprocessing method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             return ()
 
@@ -1113,6 +1357,7 @@ if casa_enabled:
                 product=None,
                 config=None,
                 imaging_method='tclean',
+                postprocessing_method="casa",
                 in_tag='pbcorr_trimmed_k',
                 out_tag='pbcorr_trimmed_k_fits',
                 do_pb_too=True,
@@ -1126,6 +1371,9 @@ if casa_enabled:
             For one target, config, product combination export to
             FITS. Optionally also export the primary beam files.
             """
+            
+            if postprocessing_method not in ALLOWED_POSTPROCESSING_METHODS:
+                raise ValueError(f"postprocessing method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             # Generate file names
 
@@ -1142,8 +1390,10 @@ if casa_enabled:
             # Check input file existence
 
             if check_files:
-                if not (os.path.isdir(indir + infile)):
-                    logger.warning("Missing " + infile)
+                files_exist = check_files_exist(indir + infile,
+                                                postprocessing_method=postprocessing_method,
+                                                )
+                if not files_exist:
                     return ()
 
             # Export to FITS and clean up output
@@ -1155,24 +1405,39 @@ if casa_enabled:
             logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%")
             logger.info("")
 
-            logger.info("Using ccr.export_and_cleanup.")
+            logger.info("Using export_and_cleanup.")
             logger.info("Export to " + outfile)
             logger.info("Writing from input cube " + infile)
 
             if not self._dry_run:
-                ccr.export_and_cleanup(
-                    infile=indir + infile,
-                    outfile=outdir + outfile,
-                    overwrite=True,
-                    remove_cards=[],
-                    add_cards={'OBJECT': target.upper()},
-                    add_history=[],
-                    zap_history=True,
-                    round_beam=True,
-                    roundbeam_tol=0.01,
-                )
+                if postprocessing_method == "casa":
+                    ccr.export_and_cleanup(
+                        infile=indir + infile,
+                        outfile=outdir + outfile,
+                        overwrite=True,
+                        remove_cards=[],
+                        add_cards={'OBJECT': target.upper()},
+                        add_history=[],
+                        zap_history=True,
+                        round_beam=True,
+                        roundbeam_tol=0.01,
+                    )
+                elif postprocessing_method == "spectralcube":
+                    scr.export_and_cleanup(
+                        infile=f"{indir}{infile}.fits",
+                        outfile=outdir + outfile,
+                        overwrite=True,
+                        remove_cards=[],
+                        add_cards={"OBJECT": target.upper()},
+                        add_history=[],
+                        zap_history=True,
+                        round_beam=True,
+                        roundbeam_tol=0.01,
+                    )
+                else:
+                    raise ValueError(f"postprocessing method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
-            if do_pb_too is False:
+            if not do_pb_too:
                 return ()
 
             # Check input file existence
@@ -1181,25 +1446,42 @@ if casa_enabled:
             outfile_pb = fname_dict_out[out_pb_tag]
 
             if check_files:
-                if not (os.path.isdir(indir + infile_pb)):
-                    logger.warning("Missing " + infile_pb)
+                files_exist = check_files_exist(indir + infile_pb,
+                                                postprocessing_method=postprocessing_method,
+                                                )
+                if not files_exist:
                     return ()
 
             logger.info("Writing from primary beam " + infile_pb)
             logger.info("Writing output primary beam " + outfile_pb)
 
             if not self._dry_run:
-                ccr.export_and_cleanup(
-                    infile=indir + infile_pb,
-                    outfile=outdir + outfile_pb,
-                    overwrite=True,
-                    remove_cards=[],
-                    add_cards={'OBJECT': target.upper()},
-                    add_history=[],
-                    zap_history=True,
-                    round_beam=False,
-                    roundbeam_tol=0.01,
-                )
+                if postprocessing_method == "casa":
+                    ccr.export_and_cleanup(
+                        infile=indir + infile_pb,
+                        outfile=outdir + outfile_pb,
+                        overwrite=True,
+                        remove_cards=[],
+                        add_cards={'OBJECT': target.upper()},
+                        add_history=[],
+                        zap_history=True,
+                        round_beam=False,
+                        roundbeam_tol=0.01,
+                    )
+                elif postprocessing_method == "spectralcube":
+                    scr.export_and_cleanup(
+                        infile=f"{indir}{infile_pb}.fits",
+                        outfile=outdir + outfile_pb,
+                        overwrite=True,
+                        remove_cards=[],
+                        add_cards={'OBJECT': target.upper()},
+                        add_history=[],
+                        zap_history=True,
+                        round_beam=False,
+                        roundbeam_tol=0.01,
+                    )
+                else:
+                    raise ValueError(f"postprocessing method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             return ()
 
@@ -1208,6 +1490,7 @@ if casa_enabled:
                 target=None,
                 product=None,
                 config=None,
+                postprocessing_method="casa",
                 in_tag='pbcorr_round',
                 out_tag='linmos_commonres',
                 extra_ext_in='',
@@ -1220,6 +1503,9 @@ if casa_enabled:
             common angular resolution, appropriate for gridding together
             into a single image.
             """
+            
+            if postprocessing_method not in ALLOWED_POSTPROCESSING_METHODS:
+                raise ValueError(f"postprocessing_method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             # Generate file names
 
@@ -1244,11 +1530,20 @@ if casa_enabled:
                 )
 
                 infile = indir + this_part_dict_in[in_tag]
-                infile_exists = os.path.isdir(infile)
+                
+                infile_exists = check_files_exist(infile,
+                                                  postprocessing_method=postprocessing_method,
+                                                  )
 
                 outfile = outdir + this_part_dict_out[out_tag]
 
                 if infile_exists:
+
+                    # Append a .fits if we're using spectral-cube
+                    if postprocessing_method == "spectralcube":
+                        infile += ".fits"
+                        outfile += ".fits"
+
                     infile_list.append(infile)
                     outfile_list.append(outfile)
                 else:
@@ -1264,7 +1559,7 @@ if casa_enabled:
             logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%")
             logger.info("")
 
-            logger.info("Using cmr.common_res_for_mosaic.")
+            logger.info("Using common_res_for_mosaic.")
             logger.info("Convolving " + target)
             logger.info("Convolving original files " + str(infile_list))
             logger.info("Convolving to convolved output " + str(outfile_list))
@@ -1281,14 +1576,26 @@ if casa_enabled:
             # resolution and (maybe?) pixel padding.
 
             if not self._dry_run:
-                cmr.common_res_for_mosaic(
-                    infile_list=infile_list,
-                    outfile_list=outfile_list,
-                    do_convolve=True,
-                    target_res=target_res,
-                    pixel_padding=pixel_padding,
-                    overwrite=True,
-                )
+                if postprocessing_method == "casa":
+                    cmr.common_res_for_mosaic(
+                        infile_list=infile_list,
+                        outfile_list=outfile_list,
+                        do_convolve=True,
+                        target_res=target_res,
+                        pixel_padding=pixel_padding,
+                        overwrite=True,
+                    )
+                elif postprocessing_method == "spectralcube":
+                    smr.common_res_for_mosaic(
+                        infile_list=infile_list,
+                        outfile_list=outfile_list,
+                        do_convolve=True,
+                        target_res=target_res,
+                        pixel_padding=pixel_padding,
+                        overwrite=True,
+                    )
+                else:
+                    raise ValueError(f"postprocessing_method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             return ()
 
@@ -1297,6 +1604,7 @@ if casa_enabled:
                 target=None,
                 product=None,
                 config=None,
+                postprocessing_method="casa",
                 in_tags=['linmos_commonres', 'weight', 'prepped_sd', 'sd_weight'],
                 out_tags=['linmos_aligned', 'weight_aligned', 'sd_aligned', 'sd_weight_aligned'],
                 extra_ext_in='',
@@ -1308,6 +1616,9 @@ if casa_enabled:
             mosaic, align all parts of the mosaic to a common astrometric
             grid for combination into a single image.
             """
+            
+            if postprocessing_method not in ALLOWED_POSTPROCESSING_METHODS:
+                raise ValueError(f"postprocessing_method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             # Map the input and output tags to one another in a dictionary
 
@@ -1350,11 +1661,19 @@ if casa_enabled:
                     this_tag_out = out_tag_dict[this_tag_in]
 
                     infile = indir + this_part_dict_in[this_tag_in]
-                    infile_exists = os.path.isdir(infile)
+                    infile_exists = check_files_exist(infile,
+                                                      postprocessing_method=postprocessing_method,
+                                                      )
 
                     outfile = outdir + this_part_dict_out[this_tag_out]
 
                     if infile_exists:
+                        
+                        # Append the .fits if we're postprocessing using spectralcube
+                        if postprocessing_method == "spectralcube":
+                            infile += ".fits"
+                            outfile += ".fits"
+                        
                         infile_list.append(infile)
                         outfile_list.append(outfile)
                     else:
@@ -1370,33 +1689,48 @@ if casa_enabled:
             logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%")
             logger.info("")
 
-            logger.info("Using cmr.common_grid_for_mosaic.")
+            logger.info("Using common_grid_for_mosaic.")
             logger.info("Aligning " + target)
             logger.info("Convolving original files " + str(infile_list))
             logger.info("Convolving to convolved output " + str(outfile_list))
 
-            # TBD implement overrides
-
-            ra_ctr = None
-            dec_ctr = None
-            delta_ra = None
-            delta_dec = None
-
             if not self._dry_run:
-                cmr.common_grid_for_mosaic(
-                    infile_list=infile_list,
-                    outfile_list=outfile_list,
-                    ra_ctr=ra_ctr,
-                    dec_ctr=dec_ctr,
-                    delta_ra=delta_ra,
-                    delta_dec=delta_dec,
-                    allow_big_image=False,
-                    too_big_pix=1e4,
-                    asvelocity=True,
-                    interpolation='cubic',
-                    axes=[-1],
-                    overwrite=True,
-                )
+                if postprocessing_method == "casa":
+                    # TBD implement overrides
+                    ra_ctr = None
+                    dec_ctr = None
+                    delta_ra = None
+                    delta_dec = None
+                    
+                    cmr.common_grid_for_mosaic(
+                        infile_list=infile_list,
+                        outfile_list=outfile_list,
+                        ra_ctr=ra_ctr,
+                        dec_ctr=dec_ctr,
+                        delta_ra=delta_ra,
+                        delta_dec=delta_dec,
+                        allow_big_image=False,
+                        too_big_pix=1e4,
+                        asvelocity=True,
+                        interpolation='cubic',
+                        axes=[-1],
+                        overwrite=True,
+                    )
+                elif postprocessing_method == "spectralcube":
+
+                    # Set up name for the template cubes
+                    template_name = os.path.join(outdir, f"{target}_{config}_{product}_linmos_template.fits")
+
+                    smr.common_grid_for_mosaic(
+                        infile_list=infile_list,
+                        outfile_list=outfile_list,
+                        template_name=template_name,
+                        allow_big_image=False,
+                        too_big_pix=1e4,
+                        overwrite=True,
+                    )
+                else:
+                    raise ValueError(f"postprocessing_method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             return ()
 
@@ -1405,6 +1739,7 @@ if casa_enabled:
                 target=None,
                 product=None,
                 config=None,
+                postprocessing_method="casa",
                 image_tag='linmos_aligned',  # 'sd_aligned'
                 weight_tag='weight_aligned',  # 'sd_weight_aligned'
                 out_tag='pbcorr_round',  # 'prepped_sd'
@@ -1418,6 +1753,9 @@ if casa_enabled:
             linear mosaic. Needs to be run separately for single dish and
             interferometer data.
             """
+
+            if postprocessing_method not in ALLOWED_POSTPROCESSING_METHODS:
+                raise ValueError(f"postprocessing_method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             # Set input and output directories and define output file
 
@@ -1440,7 +1778,9 @@ if casa_enabled:
             for this_part in mosaic_parts:
 
                 this_part_dict_in = self._fname_dict(
-                    target=this_part, config=config, product=product,
+                    target=this_part,
+                    config=config,
+                    product=product,
                     extra_ext=extra_ext_in,
                 )
 
@@ -1448,10 +1788,19 @@ if casa_enabled:
                 infile = indir + this_part_dict_in[image_tag]
                 weightfile = indir + this_part_dict_in[weight_tag]
 
-                infile_exists = os.path.isdir(infile)
-                weightfile_exists = os.path.isdir(weightfile)
+                infile_exists = check_files_exist(infile,
+                                                  postprocessing_method=postprocessing_method,
+                                                  )
+                weightfile_exists = check_files_exist(weightfile,
+                                                      postprocessing_method=postprocessing_method,
+                                                      )
 
                 if infile_exists and weightfile_exists:
+                    
+                    if postprocessing_method == "spectralcube":
+                        infile += ".fits"
+                        weightfile += ".fits"
+                    
                     infile_list.append(infile)
                     weightfile_list.append(weightfile)
                 else:
@@ -1473,17 +1822,34 @@ if casa_enabled:
             logger.info("&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%&%")
             logger.info("")
 
-            logger.info("Using cmr.mosaic_aligned_data.")
+            logger.info("Using mosaic_aligned_data.")
             logger.info("Creating " + outfile)
             logger.info("Mosaicking original files " + str(infile_list))
             logger.info("Weighting by " + str(weightfile_list))
 
             if not self._dry_run:
-                cmr.mosaic_aligned_data(
-                    infile_list=infile_list,
-                    weightfile_list=weightfile_list,
-                    outfile=outdir + outfile,
-                    overwrite=True)
+                if postprocessing_method == "casa":
+                    cmr.mosaic_aligned_data(
+                        infile_list=infile_list,
+                        weightfile_list=weightfile_list,
+                        outfile=outdir + outfile,
+                        overwrite=True,
+                    )
+                elif postprocessing_method == "spectralcube":
+
+                    template_name = os.path.join(
+                        outdir, f"{target}_{config}_{product}_linmos_template.fits"
+                    )
+                    
+                    smr.mosaic_aligned_data(
+                        infile_list=infile_list,
+                        weightfile_list=weightfile_list,
+                        template_name=template_name,
+                        outfile=f"{outdir}{outfile}.fits",
+                        overwrite=True,
+                    )
+                else:
+                    raise ValueError(f"postprocessing_method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             return ()
 
@@ -1492,13 +1858,13 @@ if casa_enabled:
         # region Recipes execute a set of linked tasks for one data set.
 
         def recipe_prep_one_target(
-                self,
-                target=None,
-                product=None,
-                config=None,
-                check_files=True,
-                imaging_method='tclean',
-                trim_coarse_beam_edge_channels=False,
+            self,
+            target=None,
+            product=None,
+            config=None,
+            check_files=True,
+            imaging_method: str = "tclean",
+            postprocessing_method: str = "casa",
         ):
             """
             Recipe that takes data from imaging through all steps that
@@ -1533,7 +1899,7 @@ if casa_enabled:
                 product=product,
                 check_files=check_files,
                 imaging_method=imaging_method,
-                trim_coarse_beam_edge_channels=trim_coarse_beam_edge_channels,
+                postprocessing_method=postprocessing_method,
             )
 
             self.task_pbcorr(
@@ -1541,7 +1907,8 @@ if casa_enabled:
                 config=config,
                 product=product,
                 check_files=check_files,
-                imaging_method=imaging_method
+                imaging_method=imaging_method,
+                postprocessing_method=postprocessing_method,
             )
 
             self.task_round_beam(
@@ -1549,7 +1916,8 @@ if casa_enabled:
                 config=config,
                 product=product,
                 check_files=check_files,
-                imaging_method=imaging_method
+                imaging_method=imaging_method,
+                postprocessing_method=postprocessing_method,
             )
 
             if has_singledish and imaging_method not in ['sdintimaging']:
@@ -1557,7 +1925,8 @@ if casa_enabled:
                     target=target,
                     config=config,
                     product=product,
-                    check_files=check_files
+                    check_files=check_files,
+                    postprocessing_method=postprocessing_method,
                 )
 
             if is_part_of_mosaic:
@@ -1567,7 +1936,8 @@ if casa_enabled:
                     product=product,
                     check_files=check_files,
                     scale_by_noise=True,
-                    imaging_method=imaging_method
+                    imaging_method=imaging_method,
+                    postprocessing_method=postprocessing_method,
                 )
 
             if is_part_of_mosaic and has_singledish and imaging_method not in ['sdintimaging']:
@@ -1576,6 +1946,7 @@ if casa_enabled:
                     config=config,
                     product=product,
                     check_files=check_files,
+                    postprocessing_method=postprocessing_method,
                 )
 
             return ()
@@ -1586,6 +1957,7 @@ if casa_enabled:
                 product=None,
                 config=None,
                 imaging_method='tclean',
+                postprocessing_method='casa',
                 check_files=True,
                 extra_ext_in='',
                 extra_ext_out='',
@@ -1594,6 +1966,9 @@ if casa_enabled:
             Linearly mosaic a single target, performing the convolution,
             alignment, and mosaicking steps.
             """
+
+            if postprocessing_method not in ALLOWED_POSTPROCESSING_METHODS:
+                raise ValueError(f"postprocessing_method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             # Check that the target is a mosaic
 
@@ -1641,6 +2016,7 @@ if casa_enabled:
                 target=target,
                 product=product,
                 config=config,
+                postprocessing_method=postprocessing_method,
                 in_tag='pbcorr_round',
                 out_tag='linmos_commonres',
                 extra_ext_in=extra_ext_in,
@@ -1661,6 +2037,7 @@ if casa_enabled:
                 target=target,
                 product=product,
                 config=config,
+                postprocessing_method=postprocessing_method,
                 in_tags=in_tag_list,
                 out_tags=out_tag_list,
                 extra_ext_in=extra_ext_in,
@@ -1672,9 +2049,10 @@ if casa_enabled:
                 target=target,
                 product=product,
                 config=config,
-                image_tag='linmos_aligned',
-                weight_tag='weight_aligned',
-                out_tag='pbcorr_round',
+                postprocessing_method=postprocessing_method,
+                image_tag="linmos_aligned",
+                weight_tag="weight_aligned",
+                out_tag="pbcorr_round",
                 extra_ext_in=extra_ext_in,
                 extra_ext_out=extra_ext_out,
                 check_files=check_files,
@@ -1685,9 +2063,10 @@ if casa_enabled:
                     target=target,
                     product=product,
                     config=config,
-                    image_tag='sd_aligned',
-                    weight_tag='sd_weight_aligned',
-                    out_tag='prepped_sd',
+                    postprocessing_method=postprocessing_method,
+                    image_tag="sd_aligned",
+                    weight_tag="sd_weight_aligned",
+                    out_tag="prepped_sd",
                     extra_ext_in=extra_ext_in,
                     extra_ext_out=extra_ext_out,
                     check_files=check_files,
@@ -1702,6 +2081,7 @@ if casa_enabled:
                 config=None,
                 check_files=True,
                 ext_ext='',
+                postprocessing_method="casa",
         ):
             """
             Recipe that cleans up the output for one target, converting to
@@ -1709,72 +2089,43 @@ if casa_enabled:
             as a FITS file.
             """
 
+            if postprocessing_method not in ALLOWED_POSTPROCESSING_METHODS:
+                raise ValueError(f"postprocessing method should be one of {ALLOWED_POSTPROCESSING_METHODS}")
+
             self.task_compress(
-                target=target, config=config, product=product,
-                check_files=check_files, do_pb_too=True,
+                target=target,
+                config=config,
+                product=product,
+                check_files=check_files,
+                postprocessing_method=postprocessing_method,
+                do_pb_too=True,
                 do_trimrind=True,
-                extra_ext_in=ext_ext, extra_ext_out=ext_ext
+                extra_ext_in=ext_ext,
+                extra_ext_out=ext_ext,
             )
 
             self.task_convert_units(
-                target=target, config=config, product=product,
+                target=target,
+                config=config,
+                product=product,
                 check_files=check_files,
-                extra_ext_in=ext_ext, extra_ext_out=ext_ext
+                postprocessing_method=postprocessing_method,
+                extra_ext_in=ext_ext,
+                extra_ext_out=ext_ext,
             )
 
             self.task_export_to_fits(
-                target=target, config=config, product=product,
-                check_files=check_files, do_pb_too=True,
-                extra_ext_in=ext_ext, extra_ext_out=ext_ext
+                target=target,
+                config=config,
+                product=product,
+                check_files=check_files,
+                postprocessing_method=postprocessing_method,
+                do_pb_too=True,
+                extra_ext_in=ext_ext,
+                extra_ext_out=ext_ext,
             )
 
             return ()
-
-        def recipe_convolve_to_scale(
-                self,
-                target=None,
-                product=None,
-                config=None,
-                ext_ext='',
-                export_to_fits=True,
-                check_files=True,
-        ):
-            """
-            Convolve a target, product, config combination to a succession
-            of angulars scale using the task that convolves to a round
-            beam.
-            """
-
-            res_list = self._kh.get_res_for_config(config)
-            if res_list is None:
-                logger.error("No target resolutions found for config " + config)
-                return ()
-
-            for this_res in res_list:
-                check_target_is_part, target_name = self._kh.is_target_in_mosaic(target, return_target_name=True)
-
-                # res_tag = self._kh.get_tag_for_res(this_res)
-                res_tag = utilsResolutions.get_tag_for_res(this_res)
-                res_arcsec = utilsResolutions.get_angular_resolution_for_res(this_res,
-                                                                             distance=self._kh.get_distance_for_target(
-                                                                                 target_name))
-
-                # Check if the requested beam is smaller than the current one
-
-                self.task_round_beam(
-                    target=target, config=config, product=product,
-                    in_tag='pbcorr_trimmed_k', out_tag='pbcorr_trimmed_k',
-                    extra_ext_in=ext_ext, extra_ext_out=ext_ext + '_res' + res_tag,
-                    force_beam_as=res_arcsec,
-                    check_files=check_files
-                )
-
-                if export_to_fits:
-                    self.task_export_to_fits(
-                        target=target, config=config, product=product,
-                        check_files=check_files, do_pb_too=True,
-                        extra_ext_in=ext_ext + '_res' + res_tag, extra_ext_out=ext_ext + '_res' + res_tag,
-                    )
 
         # endregion
 
@@ -1782,7 +2133,8 @@ if casa_enabled:
 
         def loop_postprocess(
                 self,
-                imaging_method: str = 'tclean',
+                imaging_method: str = "tclean",
+                postprocessing_method: str = "casa",
                 do_all: bool = False,
                 do_prep: bool = False,
                 do_feather: bool = False,
@@ -1804,6 +2156,8 @@ if casa_enabled:
             Args:
                 imaging_method (str, optional): Imaging method used. Should
                     be one of 'tclean', 'sdintimaging'. Defaults to 'tclean'.
+                postprocessing_method (str, optional): Postprocessing method.
+                    Should be one of 'casa', 'spectralcube'. Defaults to 'casa'.
                 do_all (bool, optional): If True, run all steps. Defaults to False.
                 do_prep (bool, optional): If True, run the preparation steps. Defaults to False.
                 do_feather (bool, optional): If True, run the feathering steps. Defaults to False.
@@ -1819,6 +2173,9 @@ if casa_enabled:
                 make_directories (bool, optional): If True, will make directories that don't already exist.
                     Defaults to True.
             """
+            
+            if postprocessing_method not in ALLOWED_POSTPROCESSING_METHODS:
+                raise ValueError(f"Postprocessing method must be one of {ALLOWED_POSTPROCESSING_METHODS}")
 
             if do_all:
                 do_prep = True
@@ -1890,8 +2247,8 @@ if casa_enabled:
                         product=this_product,
                         config=this_config,
                         check_files=True,
-                        trim_coarse_beam_edge_channels=trim_coarse_beam_edge_channels,
                         imaging_method=imaging_method_prep,
+                        postprocessing_method=postprocessing_method,
                     )
 
             # Feather the interferometer configuration data that has
@@ -1940,10 +2297,11 @@ if casa_enabled:
                             product=this_product,
                             config=this_config,
                             apodize=True,
-                            apod_ext='pb',
-                            extra_ext_out='_apod',
+                            apod_ext="pb",
+                            extra_ext_out="_apod",
                             check_files=True,
                             copy_weights=True,
+                            postprocessing_method=postprocessing_method,
                         )
 
                     if feather_noapod:
@@ -1952,13 +2310,13 @@ if casa_enabled:
                             product=this_product,
                             config=this_config,
                             apodize=False,
-                            extra_ext_out='',
+                            extra_ext_out="",
                             check_files=True,
                             copy_weights=True,
+                            postprocessing_method=postprocessing_method,
                         )
 
             # Mosaic the interferometer, single dish, and feathered data.
-
             if do_mosaic:
 
                 # Loop over interferometer configurations
@@ -1976,9 +2334,12 @@ if casa_enabled:
                     # astrometric grid).
 
                     self.recipe_mosaic_one_target(
-                        target=this_target, product=this_product, config=this_config,
+                        target=this_target,
+                        product=this_product,
+                        config=this_config,
                         check_files=True,
                         imaging_method=imaging_method,
+                        postprocessing_method=postprocessing_method,
                         extra_ext_in='',
                         extra_ext_out='',
                     )
@@ -1999,18 +2360,24 @@ if casa_enabled:
 
                     if feather_apod:
                         self.recipe_mosaic_one_target(
-                            target=this_target, product=this_product, config=this_config,
+                            target=this_target,
+                            product=this_product,
+                            config=this_config,
                             check_files=True,
-                            extra_ext_in='_apod',
-                            extra_ext_out='',
+                            postprocessing_method=postprocessing_method,
+                            extra_ext_in="_apod",
+                            extra_ext_out="",
                         )
 
                     if feather_noapod:
                         self.recipe_mosaic_one_target(
-                            target=this_target, product=this_product, config=this_config,
+                            target=this_target,
+                            product=this_product,
+                            config=this_config,
                             check_files=True,
-                            extra_ext_in='',
-                            extra_ext_out='',
+                            postprocessing_method=postprocessing_method,
+                            extra_ext_in="",
+                            extra_ext_out="",
                         )
 
             # This round of feathering targets only mosaicked data, and only if we haven't feathered before mosaicking.
@@ -2034,9 +2401,10 @@ if casa_enabled:
                             product=this_product,
                             config=this_config,
                             apodize=True,
-                            apod_ext='pb',
-                            extra_ext_out='_apod',
+                            apod_ext="pb",
+                            extra_ext_out="_apod",
                             check_files=True,
+                            postprocessing_method=postprocessing_method,
                         )
 
                     if feather_noapod:
@@ -2045,8 +2413,9 @@ if casa_enabled:
                             product=this_product,
                             config=this_config,
                             apodize=False,
-                            extra_ext_out='',
+                            extra_ext_out="",
                             check_files=True,
+                            postprocessing_method=postprocessing_method,
                         )
 
             # Trim and downsample the data, convert to Kelvin, etc.
@@ -2062,14 +2431,20 @@ if casa_enabled:
                     # config files
 
                     if imaging_method == 'sdintimaging':
-                        self.task_rename_sdintimaging(target=this_target, product=this_product, config=this_config,
-                                                      imaging_method=imaging_method)
+                        self.task_rename_sdintimaging(target=this_target, 
+                                                      product=this_product, 
+                                                      config=this_config,
+                                                      imaging_method=imaging_method,
+                                                      postprocessing_method=postprocessing_method,
+                                                      )
 
                     self.recipe_cleanup_one_target(
                         target=this_target,
                         product=this_product,
                         config=this_config,
-                        check_files=True)
+                        check_files=True,
+                        postprocessing_method=postprocessing_method,
+                    )
 
             # Build reports summarizing the properties of the final
             # postprocessed data.

--- a/phangsPipeline/scCubeRoutines.py
+++ b/phangsPipeline/scCubeRoutines.py
@@ -1,0 +1,859 @@
+import logging
+import os
+
+import astropy.units as u
+import numpy as np
+import scipy.ndimage as nd
+from astropy.convolution import convolve, convolve_fft
+from astropy.io import fits
+from astropy.utils.console import ProgressBar
+from astropy.wcs import WCS
+from astropy.wcs.utils import proj_plane_pixel_scales
+from radio_beam import Beam
+from spectral_cube import SpectralCube, VaryingResolutionSpectralCube
+from spectral_cube.utils import NoBeamError
+
+from . import __version__
+
+# Logging
+logger = logging.getLogger(__name__)
+
+
+def create_large_fits(
+    f: str,
+    header: fits.header.Header,
+):
+    """Create a large FITS file without loading large array into memory
+
+    Args:
+        f (str): Output file name
+        header (fits.header.Header): FITS header to use for the output file
+    """
+
+    header.tofile(f, overwrite=True)
+
+    shape = tuple(header[f"NAXIS{ii}"] for ii in range(1, header["NAXIS"] + 1))
+    with open(f, "rb+") as fobj:
+        file_length = len(header.tostring()) + (np.prod(shape) * np.abs(header["BITPIX"] // 8))
+        file_length = ((file_length + 2880 - 1) // 2880) * 2880 - 1
+        fobj.seek(file_length)
+        fobj.write(b"\0")
+
+    return True
+
+
+def reproject_to_other_cube(
+    input_cube: SpectralCube,
+    target_cube: SpectralCube,
+):
+    """Spectrally interpolate and then reproject a cube slice-by-slice to the WCS of another
+
+    Args:
+        input_cube (SpectralCube): Cube to reproject
+        target_cube (SpectralCube): Cube to reproject to
+
+    Returns:
+        SpectralCube: The reprojected cube
+    """
+
+    # Start with spectral interpolation, only if we're not on the same spectral grid
+    in_spec_axis = input_cube.spectral_axis
+    targ_spec_axis = target_cube.spectral_axis
+
+    do_spectral_interp = True
+    if len(in_spec_axis) == len(targ_spec_axis):
+        if np.isclose(in_spec_axis, target_cube.spectral_axis).all():
+            do_spectral_interp = False
+
+    if not do_spectral_interp:
+        reproj_cube = input_cube.with_mask(input_cube.mask)
+    else:
+        logger.info("Performing spectral interpolation to match target cube")
+
+        reproj_cube = input_cube.spectral_interpolate(target_cube.spectral_axis)
+
+    # Next up is spatial reprojection, where we check the celestial WCS to see if we need
+    # to do this
+    spatial_wcs_match = reproj_cube.wcs.celestial.wcs.compare(target_cube.wcs.celestial.wcs)
+    shape_match = reproj_cube.shape == target_cube.shape
+
+    if not spatial_wcs_match or not shape_match:
+        logger.info("Performing spatial regridding to match target cube")
+
+        # Build a 2D header for the reprojection
+        hdr_2d = target_cube.wcs.celestial.to_header()
+        hdr_2d["NAXIS"] = 2
+        hdr_2d["NAXIS1"] = target_cube.wcs.pixel_shape[0]
+        hdr_2d["NAXIS2"] = target_cube.wcs.pixel_shape[1]
+
+        # Create an empty array to put values into. Use float32 to save space
+        # and for consistency elsewhere
+        full_cube_array = np.ones(target_cube.shape, dtype=np.float32) * np.nan
+
+        # Do each slice of the reprojection. Use a progress bar since this
+        # is quite slow
+        with ProgressBar(reproj_cube.shape[0]) as bar:
+            for i in range(reproj_cube.shape[0]):
+                slice_reproj = reproj_cube[i, :, :].reproject(hdr_2d)
+                full_cube_array[i, :, :] = slice_reproj.filled_data[:]
+
+                bar.update()
+
+        # Build a new cube to put these reprojected slices into
+        meta = reproj_cube.meta
+        try:
+            beam = reproj_cube.beam
+        except NoBeamError:
+            beam = None
+
+        mask = np.isfinite(full_cube_array)
+
+        reproj_cube = SpectralCube(
+            data=full_cube_array,
+            wcs=target_cube.wcs,
+            meta=meta,
+            header=target_cube.header,
+            beam=beam,
+        )
+
+        # Add in the mask
+        reproj_cube = reproj_cube.with_mask(mask)
+
+    return reproj_cube
+
+
+def reproject_to_other_wcs(
+    cube: SpectralCube,
+    wcs: WCS,
+):
+    """Spectrally interpolate and then reproject a cube slice-by-slice to a target WCS
+
+    Args:
+        cube (SpectralCube): Cube to reproject
+        wcs (WCS): Target WCS
+
+    Returns:
+        SpectralCube: The reprojected cube
+    """
+
+    # Reproject to WCS. Start by getting out the spectral axis for interpolation
+    w_spec = wcs.spectral
+    w_spec_len = wcs.array_shape[0]
+    w_spec_vals = w_spec.pixel_to_world(range(w_spec_len))
+
+    # Start with spectral interpolation, only if we're not on the same spectral grid
+    in_spec_axis = cube.spectral_axis
+
+    do_spectral_interp = True
+    if len(in_spec_axis) == len(w_spec_vals):
+        if np.isclose(in_spec_axis, w_spec_vals).all():
+            do_spectral_interp = False
+
+    if not do_spectral_interp:
+        reproj_cube = cube.with_mask(cube.mask)
+    else:
+        logger.info("Performing spectral interpolation to match target WCS")
+        reproj_cube = cube.spectral_interpolate(w_spec_vals)
+
+    # Next up is spatial reprojection, where we check the celestial WCS to see if we need
+    # to do this
+    spatial_wcs_match = reproj_cube.wcs.celestial.wcs.compare(wcs.celestial.wcs)
+    shape_match = reproj_cube.shape == wcs.array_shape
+    if not spatial_wcs_match or not shape_match:
+        logger.info("Performing spatial regridding to match target WCS")
+
+        # Build a final header
+        hdr = wcs.to_header()
+
+        # We need to add in NAXIS as well
+        hdr["NAXIS"] = len(wcs.pixel_shape)
+        hdr["NAXIS1"] = wcs.pixel_shape[0]
+        hdr["NAXIS2"] = wcs.pixel_shape[1]
+        hdr["NAXIS3"] = wcs.pixel_shape[2]
+
+        # Build a 2D header for the reprojection
+        hdr_2d = wcs.celestial.to_header()
+        hdr_2d["NAXIS"] = 2
+        hdr_2d["NAXIS1"] = wcs.pixel_shape[0]
+        hdr_2d["NAXIS2"] = wcs.pixel_shape[1]
+
+        # Create an empty array to put values into. Use float32 to save space
+        # and for consistency elsewhere
+        full_cube_array = np.ones(wcs.array_shape, dtype=np.float32) * np.nan
+
+        # Do each slice of the reprojection. Use a progress bar since this
+        # is quite slow
+        with ProgressBar(reproj_cube.shape[0]) as bar:
+            for i in range(reproj_cube.shape[0]):
+                slice_reproj = reproj_cube[i, :, :].reproject(hdr_2d)
+                full_cube_array[i, :, :] = slice_reproj.filled_data[:]
+
+                bar.update()
+
+        # Build a new cube to put these reprojected slices into
+        meta = reproj_cube.meta
+        try:
+            beam = reproj_cube.beam
+        except NoBeamError:
+            beam = None
+
+        mask = np.isfinite(full_cube_array)
+
+        reproj_cube = SpectralCube(
+            data=full_cube_array,
+            wcs=wcs,
+            meta=meta,
+            header=hdr,
+            beam=beam,
+        )
+
+        # Add in the mask
+        reproj_cube = reproj_cube.with_mask(mask)
+
+    return reproj_cube
+
+
+def check_wcs_match(
+    cube1: SpectralCube,
+    cube2: SpectralCube,
+):
+    """Check if two cubes have the same wcs.
+
+    Args:
+        cube1 (SpectralCube): First cube
+        cube2 (SpectralCube): Second cube
+
+    Returns:
+        bool: True if cubes have the same WCS, False otherwise
+    """
+
+    # Check shape
+    if cube1.shape != cube2.shape:
+        logger.error("Shape mismatch!")
+        return False
+    
+    # Check spectral
+    spectral_wcs_match = np.isclose(cube1.spectral_axis, cube2.spectral_axis).all()
+    if not spectral_wcs_match:
+        logger.error("Cube spectral WCS mismatch!")
+        return False
+
+    # Check spatial
+    spatial_wcs_match = cube1.wcs.celestial.wcs.compare(cube2.wcs.celestial.wcs)
+    if not spatial_wcs_match:
+        logger.error("Cube spatial WCS mismatch!")
+        return False
+
+    return True
+
+
+def export_and_cleanup(
+    infile: str | None = None,
+    outfile: str | None = None,
+    overwrite: bool = False,
+    remove_cards: list | None = None,
+    add_cards: dict | None = None,
+    add_history: list | None = None,
+    zap_history: bool = True,
+    round_beam: bool = True,
+    roundbeam_tol: float | int = 0.01,
+):
+    """
+    Do final cleanup for a cube, tidying up header keywords that are
+    usually confusing or useless. Optionally add new keywords to the header
+    and check whether the beam is close enough to being round that it makes
+    sense to overwrite it.
+
+    Args:
+        infile (str): Input file name
+        outfile (str): Output file name
+        overwrite (bool): Overwrite existing file. Default is False
+        remove_cards (list): List of keywords to remove from header
+        add_cards (dict): Dictionary of keywords to add to header
+        add_history (list): List of keywords to add to header
+        zap_history (bool): If True, zap history keywords
+        round_beam (bool): If True, then force round beam in header
+        roundbeam_tol (float | int): Fractional tolerance for round beam in header
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+
+    if infile is None:
+        logger.error("Missing required input.")
+        return False
+
+    if outfile is None:
+        logger.error("Missing required output.")
+        return False
+
+    if not os.path.exists(infile):
+        logger.error(f"Input file does not exist - {infile}")
+        return False
+
+    if os.path.isfile(outfile) and not overwrite:
+        logger.info(f"Output exists {outfile} and overwrite set to False. Will skip")
+        return True
+
+    if add_history is None:
+        add_history = []
+
+    if add_cards is None:
+        add_cards = {}
+
+    if remove_cards is None:
+        remove_cards = []
+
+    cube = SpectralCube.read(infile)
+
+    # Convert to km/s and write to outfile
+    cube = cube.with_spectral_unit(
+        u.km / u.s,
+        velocity_convention="radio",
+    )
+
+    cube.write(outfile, overwrite=True)
+
+    # Read back in with astropy so we can manipulate the header
+    with fits.open(outfile) as hdu:
+        hdr = hdu[0].header
+        data = hdu[0].data
+
+        # Cards to remove by default
+        default_cards_to_remove = [
+            "BLANK",
+            "DATE-OBS",
+            "OBSERVER",
+            "O_BLANK",
+            "O_BSCALE",
+            "O_BZERO",
+            "OBSRA",
+            "OBSDEC",
+            "OBSGEO-X",
+            "OBSGEO-Y",
+            "OBSGEO-Z",
+            "DISTANCE",
+        ]
+
+        for card in default_cards_to_remove:
+            if card in hdr.keys():
+                hdr.remove(card)
+
+        # User cards to remove
+        for card in remove_cards:
+            if card in hdr.keys():
+                hdr.remove(card)
+
+        # Delete history
+        if zap_history:
+            while "HISTORY" in hdr.keys():
+                hdr.remove("HISTORY")
+
+        # Add history
+        if len(add_history) > 0:
+            # Add a blank history if we don't have one
+            if "HISTORY" not in hdr.keys():
+                hdr["HISTORY"] = ""
+
+            # Append history lines as necessary
+            for history_line in add_history:
+                hdr["HISTORY"].append(history_line)
+
+        for card in add_cards:
+            hdr[card] = add_cards[card]
+
+        # Get the data min and max right
+        datamin = np.nanmin(data)
+        datamax = np.nanmax(data)
+
+        hdr["DATAMIN"] = datamin
+        hdr["DATAMAX"] = datamax
+
+        # Round the beam recorded in the header if it lies within the
+        # specified tolerance.
+
+        if round_beam:
+            if roundbeam_tol > 0.0:
+                bmaj = hdr["BMAJ"]
+                bmin = hdr["BMIN"]
+                if bmaj != bmin:
+                    frac_dev = np.abs(bmaj - bmin) / bmaj
+                    if frac_dev <= roundbeam_tol:
+                        logger.info("Rounding beam.")
+                        hdr["BMAJ"] = bmaj
+                        hdr["BMIN"] = bmaj
+                        hdr["BPA"] = 0.0
+                    else:
+                        logger.info("Beam too asymmetric to round.")
+                        logger.info(f"... fractional deviation: {frac_dev}")
+
+        # Never forget where you came from
+        hdr["COMMENT"] = "Produced with PHANGS-ALMA pipeline version " + __version__
+
+        hdu.writeto(outfile, overwrite=True)
+
+    return True
+
+
+def convolve_to_round_beam(
+    infile: str | None = None,
+    outfile: str | None = None,
+    convolve_fn: str = "convolve_fft",
+    nan_treatment: str = "interpolate",
+    force_beam: float | int | None = None,
+    overwrite: bool = False,
+):
+    """
+    Convolve supplied image to have a round beam. Optionally, force
+    that beam to some size, else it figures out the beam.
+
+    Args:
+        infile (str): Input file name
+        outfile (str): Output file name
+        convolve_fn (str): Convolution function name. Either "convolve"
+            or "convolve_fft". Default is "convolve_fft".
+        nan_treatment (str): Treatment to use for nan values in convolution
+        force_beam (float): Force beam to size in arcsec.
+            Default is None, which does not force the beam to any particular
+            size.
+        overwrite (bool): Overwrite existing file. Default is False
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+
+    if infile is None or outfile is None:
+        logger.error("Missing required input.")
+        return False
+
+    if not os.path.exists(infile):
+        logger.error("Input file missing - " + infile)
+        return False
+
+    if os.path.exists(outfile) and not overwrite:
+        logger.info(f"outfile {outfile} already exists and overwrite is False. Skipping")
+        return True
+
+    cube = SpectralCube.read(infile)
+    cube.allow_huge_operations = True
+
+    # Get beam from cube (convert to arcsec), and then target major axis.
+    # This is a little different depending on whether the cube is a VaryingResolutionSpectralCube
+    # or not
+    if isinstance(cube, VaryingResolutionSpectralCube):
+        beam_idx = np.argmax([b.major.to(u.arcsec).value for b in cube.beams])
+        beam = cube.beams[beam_idx]
+    else:
+        beam = cube.beam
+
+    bmaj = beam.major
+    bmaj = bmaj.to(u.arcsec)
+
+    # Get pixel scale in arcsec. Assume square pixels
+    pixel_scales = proj_plane_pixel_scales(cube.wcs.celestial) * u.deg
+    pixel_as = [p.to(u.arcsec) for p in pixel_scales][0]
+
+    # Make the beam a little larger to avoid convolution artifacts
+    if force_beam is None:
+        target_bmaj = np.sqrt(bmaj**2 + (2.0 * pixel_as) ** 2)
+    else:
+        min_bmaj = np.sqrt(bmaj**2 + (2.0 * pixel_as) ** 2)
+        if force_beam < min_bmaj:
+            logger.warning("Requested beam is too small for convolution.")
+            return False
+        target_bmaj = force_beam
+
+    # Build beam, do the convolution, write out
+    target_beam = Beam(major=target_bmaj, minor=target_bmaj, pa=0 * u.deg)
+
+    logger.info(f"Convolving to round beam - {str(target_beam)}")
+
+    if convolve_fn == "convolve":
+        conv_fn = convolve
+    elif convolve_fn == "convolve_fft":
+        conv_fn = convolve_fft
+    else:
+        raise ValueError(f"convolve_fn {convolve_fn} not recognized")
+
+    kwargs = {
+        "nan_treatment": nan_treatment,
+        "preserve_nan": True,
+    }
+
+    # Keep track of the original dtype since it can change during convolution
+    orig_dtype = cube.unmasked_data[0, 0, 0].dtype
+
+    cube = cube.convolve_to(
+        target_beam,
+        convolve=conv_fn,
+        **kwargs,
+    )
+
+    # Because this operation can change the dtype, recreate the cube
+    # Do this channel-by-channel, to keep RAM usage low
+    if cube.unmasked_data[0, 0, 0].dtype != orig_dtype:
+        create_large_fits(
+            outfile,
+            cube.header,
+        )
+
+        with fits.open(outfile, mode="update") as hdu:
+            n_chan = hdu[0].data.shape[0]
+
+            logger.info("Writing cube out channel-by-channel")
+            with ProgressBar(n_chan) as bar:
+                for chan in range(n_chan):
+                    hdu[0].data[chan] = cube.unitless_filled_data[chan].astype(orig_dtype)
+                    hdu.flush()
+                    bar.update()
+
+    else:
+        cube.write(
+            outfile,
+            overwrite=True,
+        )
+
+    return True
+
+
+def align_to_target(
+    infile: str | None = None,
+    outfile: str | None = None,
+    template: str | None = None,
+    overwrite: bool = False,
+):
+    """
+    Align one cube to another, creating a copy.
+
+    Args:
+        infile (str): Input file name
+        outfile (str): Output file name
+        template (str): Template file name
+        overwrite (bool): Overwrite existing file. Default is False
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+
+    if infile is None:
+        logger.error("Missing required input.")
+        return False
+
+    if template is None:
+        logger.error("Missing required template.")
+        return False
+
+    if outfile is None:
+        logger.error("Missing required output.")
+        return False
+
+    if not os.path.exists(infile):
+        logger.error(f"Input file missing - {infile}")
+        return False
+
+    if not os.path.exists(template):
+        logger.error(f"Template file missing - {template}")
+        return False
+
+    if os.path.exists(outfile) and not overwrite:
+        logger.info(f"outfile {outfile} already exists and overwrite is False. Skipping")
+        return True
+
+    in_cube = SpectralCube.read(infile)
+    template_cube = SpectralCube.read(template)
+
+    in_cube = reproject_to_other_cube(
+        input_cube=in_cube,
+        target_cube=template_cube,
+    )
+
+    in_cube.write(outfile, overwrite=True)
+
+    return True
+
+
+def primary_beam_correct(
+    infile: str | None = None,
+    pbfile: str | None = None,
+    outfile: str | None = None,
+    cutoff: float | int = 0.25,
+    overwrite: bool = False,
+):
+    """
+    Construct a primary-beam corrected image.
+
+    Args:
+        infile (str): Input file name
+        pbfile (str): Primary beam file name
+        outfile (str): Output file name
+        cutoff (float | int): Cutoff value for primary beam correction
+        overwrite (bool): Overwrite existing file. Default is False
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+
+    if infile is None or pbfile is None or outfile is None:
+        logger.error("Missing required input.")
+        return False
+
+    if not os.path.exists(infile):
+        logger.error(f"Input file missing - {infile}")
+        return False
+
+    if not os.path.exists(pbfile):
+        logger.error(f"Primary beam file missing - {pbfile}")
+        return False
+
+    if os.path.exists(outfile) and not overwrite:
+        logger.info(f"outfile {outfile} already exists and overwrite is False. Skipping")
+        return True
+
+    # Load in image and pb cubes
+    cube = SpectralCube.read(infile)
+    cube.allow_huge_operations = True
+    pb = SpectralCube.read(pbfile)
+    pb.allow_huge_operations = True
+
+    # Add the cutoff as a mask. The sign is greater than since True is for included
+    # data
+    mask = pb > cutoff
+
+    # Quick checks to make sure data shape and WCS are the same
+    wcs_match = check_wcs_match(cube, pb)
+    if not wcs_match:
+        return False
+
+    # Apply the PB correction. Use unmasked data to avoid unit complaints
+    cube /= pb.unmasked_data[:]
+
+    # Apply the PB mask and write out
+    cube = cube.with_mask(mask)
+    cube.write(outfile, overwrite=True)
+
+    return True
+
+
+def trim_cube(
+    infile: str | None = None,
+    outfile: str | None = None,
+    overwrite: bool = False,
+    min_pixperbeam: int = 3,
+    pad: int = 1,
+    rebin: bool = True,
+):
+    """
+    Trim empty space from around the edge of a cube. Also rebin the
+    cube to smaller size, while ensuring a minimum number of pixels
+    across the beam. Used to reduce the volume of cubes.
+
+    Args:
+        infile (str): Input file name
+        outfile (str): Output file name
+        overwrite (bool): Overwrite existing file. Default is False
+        min_pixperbeam (int): Minimum number of pixels per beam, if rebinning.
+            Default is 3.
+        pad (int): Padding around the edge of the cube. Default is 1.
+        rebin (bool): Whether to rebin the cube to some minimum number of pixels
+            per beam. Default is True.
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+
+    if infile is None or outfile is None:
+        logger.error("Missing required input.")
+        return False
+
+    if not os.path.exists(infile):
+        logger.error(f"Input file not found: {infile}")
+        return False
+
+    if os.path.exists(outfile) and not overwrite:
+        logger.info(f"outfile {outfile} already exists and overwrite is False. Skipping")
+        return True
+
+    # Load the cube in
+    cube_format = "fits"
+    if not infile.lower().endswith(".fits"):
+        cube_format = "casa"
+    cube = SpectralCube.read(infile, format=cube_format)
+    cube.allow_huge_operations = True
+
+    orig_dtype = cube.unmasked_data[0, 0, 0].dtype
+
+    if rebin:
+        # Get out pixels per beam. spectral-cube returns as an area,
+        # so sqrt
+        pixperbeam = np.sqrt(cube.pixels_per_beam)
+
+        # Calculate the rebinning factor, and rebin if >1
+        rebin_factor = int(np.floor(pixperbeam / min_pixperbeam))
+
+        if rebin_factor > 1:
+            logger.info(f"Will rebin spatial axes by a factor {rebin_factor}")
+
+            # Rebin along the spatial axes, which are 1 and 2
+            cube = cube.downsample_axis(
+                factor=rebin_factor,
+                axis=1,
+            )
+            cube = cube.downsample_axis(
+                factor=rebin_factor,
+                axis=2,
+            )
+
+    # Pull out the mask, use this to get data extent
+    mask = cube.get_mask_array()
+
+    # Loop over each axis to check the maximal extent in the mask
+    axis_slices = []
+    for ax in range(len(cube.shape)):
+        mask_spec_i = np.any(
+            mask, axis=tuple([i for i, x in enumerate(list(mask.shape)) if i != ax])
+        )
+        i_min = np.max([0, np.min(np.where(mask_spec_i)) - pad])
+        i_max = np.min([np.max(np.where(mask_spec_i)) + pad, mask.shape[ax] - 1])
+        axis_slices.append(slice(i_min, i_max + 1))
+
+    # Slice down the cube
+    cube = cube[*axis_slices]
+
+    # Do a final check against dtype
+    cube_final_dtype = cube.unmasked_data[0, 0, 0].dtype
+
+    # If we don't match, write out channel-by-channel
+    if cube_final_dtype != orig_dtype:
+
+        create_large_fits(
+            outfile,
+            cube.header,
+        )
+
+        with fits.open(outfile, mode="update") as hdu:
+            n_chan = hdu[0].data.shape[0]
+
+            logger.info("Writing out cube channel-by-channel")
+            with ProgressBar(n_chan) as bar:
+                for chan in range(n_chan):
+                    hdu[0].data[chan] = cube.unitless_filled_data[chan].astype(np.float32)
+                    hdu.flush()
+                    bar.update()
+
+    # Otherwise, just save
+    else:
+        cube.write(outfile, overwrite=True)
+
+    return True
+
+
+def trim_rind(
+    infile: str | None = None,
+    outfile: str | None = None,
+    overwrite: bool = False,
+    pixels: int = 1,
+):
+    """Binary erode a mask to trim the rind off a cube
+
+    TODO: This hasn't been explicitly tested yet, but should work.
+
+    Args:
+        infile (str): Input file name
+        outfile (str): Output file name
+        overwrite (bool): Overwrite existing file.
+            Default is False
+        pixels (int): Number of pixels to erode. Default is 1.
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+
+    if infile is None or outfile is None:
+        logger.error("Missing required input.")
+        return False
+
+    if not os.path.exists(infile):
+        logger.error(f"Input file not found: {infile}")
+        return False
+
+    if os.path.exists(outfile) and not overwrite:
+        logger.info(f"outfile {outfile} already exists and overwrite is False. Skipping")
+        return True
+
+    # Figure out the extent of the image inside the cube
+    cube = SpectralCube.read(infile)
+    mask = cube.get_mask_array()
+
+    elt = nd.generate_binary_structure(2, 1)
+    if pixels > 1:
+        elt = nd.iterate_structure(elt, pixels - 1)
+    mask = nd.binary_erosion(mask, elt[np.newaxis, :, :])
+    cube = cube.with_mask(mask, inherit_mask=False)
+
+    cube.write(outfile, overwrite=True)
+
+    return True
+
+
+def convert_units(
+    infile: str | None = None,
+    outfile: str | None = None,
+    units: str | u.Unit = "K",
+    overwrite: bool = False,
+):
+    """
+    Convert a cube to a specific unit.
+
+    Args:
+        infile (str): Input file
+        outfile (str): Output file
+        units (str | u.Unit): Unit to convert to.
+            Defaults to "K"
+        overwrite (bool): Overwrite existing file.
+            Defaults to False
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+
+    if infile is None:
+        logger.error("Missing required input.")
+        return False
+
+    if outfile is None:
+        logger.error("Missing required output.")
+        return False
+
+    if not os.path.exists(infile):
+        logger.error(f"Input file not found: {infile}")
+        return False
+
+    if os.path.exists(outfile) and not overwrite:
+        logger.error(f"Output file {outfile} already exists and overwrite is False. Will skip")
+        return True
+
+    # Read in cube and convert
+    cube = SpectralCube.read(infile)
+    cube.allow_huge_operations = True
+
+    # Do this channel by channel to avoid needing a lot of RAM
+    create_large_fits(
+        outfile,
+        cube.header,
+    )
+
+    with fits.open(outfile, mode="update") as hdu:
+        n_chan = hdu[0].data.shape[0]
+
+        logger.info(f"Converting cube to {units} channel-by-channel")
+        with ProgressBar(n_chan) as bar:
+            for chan in range(n_chan):
+                hdu[0].data[chan] = cube[chan].to(units)
+                hdu.flush()
+                bar.update()
+
+        # Finally, update the unit
+        hdu[0].header.update({"BUNIT": units})
+        hdu.flush()
+
+    return True

--- a/phangsPipeline/scFeatherRoutines.py
+++ b/phangsPipeline/scFeatherRoutines.py
@@ -1,0 +1,267 @@
+import logging
+import os
+
+import astropy.units as u
+import numpy as np
+from astropy.io import fits
+from astropy.utils.console import ProgressBar
+from spectral_cube import SpectralCube
+from uvcombine import feather_simple_cube
+
+from .scCubeRoutines import check_wcs_match, create_large_fits, reproject_to_other_cube
+
+# Logging
+logger = logging.getLogger(__name__)
+
+
+def prep_sd_for_feather(
+    sdfile_in: str | None = None,
+    sdfile_out: str | None = None,
+    interf_file: str | None = None,
+    do_align: bool = True,
+    do_checkunits: bool = True,
+    overwrite: bool = False,
+):
+    """
+    Prepare single dish data for feathering.
+
+    Args:
+        sdfile_in (str): the input single dish file. Can be a FITS file (with
+            do_import) or a CASA image.
+        sdfile_out (str): the output of the program. If all flags are called,
+            this will be a .fits image on the same astrometric grid as the
+            interferometric file with units of Jy/beam and no degenerate axes.
+        interf_file (str): the interferometric file being used in the feather
+            call. Used as a template here to astrometrically align the data.
+        do_align (bool): If True then align the single dish data to the
+            astrometric grid of the interferometer file.
+        do_checkunits (bool): If True then check the units to make
+            sure that they are in Jy/beam, which is required by feather.
+        overwrite (bool): Delete existing files. Defaults to False.
+
+    Returns:
+        bool: True if successful, False if not.
+    """
+
+    # Check inputs
+    if interf_file is None:
+        logger.error("Interferometric file not defined")
+        return False
+
+    if sdfile_in is None:
+        logger.error("Single dish file not defined")
+        return False
+
+    if not os.path.exists(interf_file):
+        logger.error(f"Interferometric file not found: {interf_file}")
+        return False
+
+    if not os.path.exists(sdfile_in):
+        logger.error(f"Single dish file not found: {sdfile_in}")
+        return False
+
+    if sdfile_out is None:
+        logger.error("Output single dish file name not supplied via sdfile_out")
+        return False
+
+    if not overwrite and os.path.exists(sdfile_out):
+        logger.info(f"Output file {sdfile_out} already exists and overwrite is False. Skipping")
+        return True
+
+    # Load in cubes. The singledish may be a CASA image, so check for that
+    cube_format = "fits"
+    if not sdfile_in.lower().endswith(".fits"):
+        cube_format = "casa"
+    sd_cube = SpectralCube.read(
+        sdfile_in,
+        format=cube_format,
+    )
+    sd_cube.allow_huge_operations = True
+
+    int_cube = SpectralCube.read(interf_file)
+
+    # Align the single dish data to the astrometric grid of the interferometric data
+    if do_align:
+        logger.info(f"Aligning {sdfile_in} to {interf_file}")
+        sd_cube = reproject_to_other_cube(
+            input_cube=sd_cube,
+            target_cube=int_cube,
+        )
+
+    # Check the units on the singledish file and convert from K to Jy/beam if needed.
+    if do_checkunits:
+        if sd_cube.unit == u.K:
+            logger.info("Unit is Kelvin. Converting to Jy/beam.")
+            sd_cube = sd_cube.to(u.Jy / u.beam)
+
+    # Make sure we're in float32 space
+    sd_cube_dtype = sd_cube.unmasked_data[0, 0, 0].dtype
+
+    # If we're not, cast it to float32. Do channel-by-channel to reduce RAM
+    if sd_cube_dtype != np.float32:
+        
+        create_large_fits(
+            sdfile_out,
+            sd_cube.header,
+        )
+
+        with fits.open(sdfile_out, mode="update") as hdu:
+            n_chan = hdu[0].data.shape[0]
+
+            logger.info("Converting cube to float32 channel-by-channel")
+            with ProgressBar(n_chan) as bar:
+                for chan in range(n_chan):
+                    hdu[0].data[chan] = sd_cube.unitless_filled_data[chan].astype(np.float32)
+                    hdu.flush()
+                    bar.update()
+
+    else:
+        sd_cube.write(sdfile_out, overwrite=True)
+
+    return True
+
+
+def feather_two_cubes(
+    interf_file: str | None = None,
+    sd_file: str | None = None,
+    out_file: str | None = None,
+    apod_file: str | None = None,
+    do_apodize: bool = False,
+    apod_cutoff: float | int = -1.0,
+    sdgain: float = 1.0,
+    overwrite: bool = False,
+):
+    """
+    Feather together interferometric and total power data using uvcombine.
+    Optionally, first apply some steps to homogenize
+    the two data sets.
+
+    TODO: Feathering with apodization hasn't been tested
+
+    Args:
+        interf_file (str): the interferometric cube to feather.
+        sd_file (str): the single dish cube to feather.
+        out_file (str): the output file name.
+        apod_file (str): the apodization file to use.
+        do_apodize (bool): if True, then apodize BOTH data sets using the provided apodization map.
+            Defaults to False.
+        apod_cutoff (float | int): the cutoff in the apodization file below which data are blanked.
+            Defaults to -1.0.
+        sdgain (float | int): the gain factor to apply to the single dish data. Defaults to 1.0.
+        overwrite (bool): if True, overwrite existing files.
+            Defaults to False
+
+    Returns:
+        bool: True if successful, False if not.
+    """
+
+    # Check inputs
+    if interf_file is None:
+        logger.error("Interferometric file not defined")
+        return False
+
+    if sd_file is None:
+        logger.error("Single-dish cube not defined")
+        return False
+
+    if out_file is None:
+        logger.error("Output file not defined")
+        return False
+
+    if do_apodize and apod_file is None:
+        logger.error("Apodization requested, but apodization file not defined")
+        return False
+
+    if not os.path.exists(sd_file):
+        logger.error(f"Single dish file not found: {sd_file}")
+        return False
+
+    if not os.path.exists(interf_file):
+        logger.error(f"Interferometric file not found: {interf_file}")
+        return False
+
+    if do_apodize and apod_file is not None and not os.path.exists(apod_file):
+        logger.error(f"Apodization requested, but file not found: {apod_file}")
+        return False
+
+    if os.path.exists(out_file) and not overwrite:
+        logger.info(f"outfile {out_file} already exists and overwrite is False. Skipping")
+        return True
+
+    # Load in cubes
+    int_cube = SpectralCube.read(interf_file)
+    sd_cube = SpectralCube.read(sd_file)
+
+    apod_data = 0
+
+    # If we're apodizing, multiply by the apod file
+    if do_apodize:
+        apod_cube = SpectralCube.read(apod_file)
+
+        # Use unmasked data to avoid unit complaints
+        apod_data = apod_cube.unmasked_data[:]
+
+        int_cube *= apod_data
+        sd_cube *= apod_data
+
+    # Check if WCS matches up, and if so disable the resampling
+    wcs_match = check_wcs_match(int_cube, sd_cube)
+
+    resample = True
+    if wcs_match:
+        resample = False
+
+    else:
+        logger.warning("WCS mismatch. Will not combine masks, and may cause issues in feathering.")
+
+    # Do the feather!
+    feathered_cube = feather_simple_cube(
+        int_cube,
+        sd_cube,
+        allow_spectral_resample=resample,
+        allow_lo_reproj=resample,
+        lowresscalefactor=sdgain,
+    )
+    feathered_cube.allow_huge_operations = True
+
+    # Apply the masks from the two cubes for safety
+    feathered_cube = feathered_cube.with_mask(int_cube.mask)
+    feathered_cube = feathered_cube.with_mask(sd_cube.mask)
+
+    # If we apodized, now divide out the common kernel.
+    if do_apodize:
+        # Make sure we actually have the apodization file
+        if apod_data == 0:
+            raise ValueError("apod_data should be defined")
+
+        feathered_cube /= apod_data
+
+        # Apply the apodization cutoff as a mask. The sign is greater than
+        # since True is for included data
+        feathered_cube = feathered_cube.with_mask(apod_data > apod_cutoff)
+
+    # Make sure we're in float32 space
+    feathered_cube_dtype = feathered_cube.unmasked_data[0, 0, 0].dtype
+
+    # If we're not, cast it to float32. Do channel-by-channel to reduce RAM
+    if feathered_cube_dtype != np.float32:
+        create_large_fits(
+            out_file,
+            feathered_cube.header,
+        )
+
+        with fits.open(out_file, mode="update") as hdu:
+            n_chan = hdu[0].data.shape[0]
+
+            logger.info("Converting cube to float32 channel-by-channel")
+            with ProgressBar(n_chan) as bar:
+                for chan in range(n_chan):
+                    hdu[0].data[chan] = feathered_cube.unitless_filled_data[chan].astype(np.float32)
+                    hdu.flush()
+                    bar.update()
+
+    else:
+        # Write out the cube
+        feathered_cube.write(out_file, overwrite=True)
+
+    return True

--- a/phangsPipeline/scMosaicRoutines.py
+++ b/phangsPipeline/scMosaicRoutines.py
@@ -1,0 +1,966 @@
+import copy
+import logging
+import os
+
+import astropy.units as u
+import numpy as np
+from astropy.convolution import convolve, convolve_fft
+from astropy.io import fits
+from astropy.utils.console import ProgressBar
+from astropy.wcs import WCS
+from astropy.wcs.utils import proj_plane_pixel_scales
+from radio_beam import Beam
+from reproject.mosaicking import find_optimal_celestial_wcs
+from spectral_cube import SpectralCube
+
+from .scCubeRoutines import create_large_fits, reproject_to_other_wcs
+from .scNoiseRoutines import mad_zero_centered
+
+# Logging
+logger = logging.getLogger(__name__)
+
+
+def build_common_header(
+    infile_list: list | None = None,
+    allow_big_image: bool = False,
+    too_big_pix: int | float = 1e4,
+):
+    """
+    Build a target header to be used as a template when
+    setting up linear mosaicking operations.
+
+    Args:
+        infile_list (list): List of input image files.
+        allow_big_image (bool, optional): If True, allow big images to be created.
+            Defaults to False.
+        too_big_pix (int|float, optional): The threshold for what constitutes a "big"
+            image in pixels. Defaults to 1e4.
+    Returns:
+        fits.header.Header: Target header.
+    """
+
+    # Check inputs
+    if infile_list is None:
+        logger.error("Missing required infile_list.")
+        return None
+
+    for this_infile in infile_list:
+        if not os.path.exists(this_infile):
+            logger.error(f"File not found {this_infile}. Returning.")
+            return None
+
+    # Loop over files, pull out cube headers
+    cube2d_hdrs = []
+    target_hdr = None
+
+    for this_infile in infile_list:
+        cube = SpectralCube.read(this_infile)
+        cube2d_hdrs.append(cube.wcs.celestial)
+
+        # If we don't have a 3D header, save that here
+        if target_hdr is None:
+            target_hdr = cube.header
+
+    # If we still don't have a 3D header, then raise an issue
+    if not isinstance(target_hdr, fits.header.Header):
+        raise ValueError("Did not find a cube header")
+
+    # Determine optimal WCS (in 2D), remembering we need to add in shape manually
+    wcs2d, shape2d = find_optimal_celestial_wcs(cube2d_hdrs)
+    optimal_2d_hdr = wcs2d.to_header()
+    optimal_2d_hdr["NAXIS1"] = shape2d[1]
+    optimal_2d_hdr["NAXIS2"] = shape2d[0]
+
+    if allow_big_image:
+        if any(shape2d) > too_big_pix:
+            logger.warning(f"This is a very big image you plan to create: {shape2d}")
+            logger.warning("To make an image this big set allow_big_image to True. Returning.")
+            return None
+
+    # Put this 2D WCS into the 3D header
+    target_hdr.update(optimal_2d_hdr)
+
+    # Ensure WCSAXES=3, if it's in the cube header
+    if target_hdr.get("WCSAXES", None) == 2:
+        target_hdr["WCSAXES"] = 3
+
+    return target_hdr
+
+
+def common_res_for_mosaic(
+    infile_list: list | None = None,
+    outfile_list: list | dict | None = None,
+    target_res: int | float | None = None,
+    pixel_padding: int | float = 2.0,
+    do_convolve: bool = True,
+    convolve_fn: str = "convolve_fft",
+    nan_treatment: str = "interpolate",
+    overwrite: bool = False,
+):
+    """
+    Convolve multi-part cubes to a common res for mosaicking.
+
+    Args:
+        infile_list (list|None): List of input image files.
+        outfile_list (list|dict|None): List or dictionary of output image files.
+        target_res (int|float|None): Target resolution in arcsec.
+        pixel_padding (int|float): Pixel padding to add to the
+            largest common beam (in quadrature) to ensure robust convolution.
+            Defaults to 2 pixels.
+        do_convolve (bool): if True, do convolution. Else just
+            calculates and returns target resolution. Defaults to True.
+        convolve_fn (str): Convolve function to use. Should be either
+            "convolve" or "convolve_fft". Defaults to "convolve_fft".
+        nan_treatment (str): Treatment to use for nan values in convolution.
+            Defaults to "interpolate".
+        overwrite (bool): if True, overwrite existing files. Defaults
+            to False.
+
+    Returns:
+        float: Common target resolution
+    """
+
+    if infile_list is None:
+        logger.error("Missing required infile_list.")
+        return None
+
+    if len(infile_list) == 0:
+        logger.error("No files to process.")
+        return None
+
+    # Check input files exist
+    for this_file in infile_list:
+        if not os.path.exists(this_file):
+            logger.error(f"File not found: {this_file}")
+            return None
+
+    # If do_convolve is True then make sure that we have output files
+    # and link those to input files
+    outfile_dict = {}
+
+    if do_convolve:
+        if outfile_list is None:
+            logger.error("Missing outfile_list required for convolution.")
+            return None
+
+        if not isinstance(outfile_list, list) and not isinstance(outfile_list, dict):
+            logger.error("outfile_list must be dictionary or list.")
+            return None
+
+        if isinstance(outfile_list, list):
+            if len(infile_list) != len(outfile_list):
+                logger.error("Mismatch in input and output list lengths.")
+                return None
+
+            outfile_dict = {}
+            for ii in range(len(infile_list)):
+                outfile_dict[infile_list[ii]] = outfile_list[ii]
+
+        if isinstance(outfile_list, dict):
+            outfile_dict = outfile_list
+
+        missing_keys = 0
+        for infile in infile_list:
+            if infile not in outfile_dict.keys():
+                logger.error(f"Missing output file for infile: {infile}")
+                missing_keys += 1
+            if missing_keys > 0:
+                logger.error(f"Missing {missing_keys} output file names.")
+                return None
+
+    if target_res is None:
+        logger.debug("Calculating target resolution ... ")
+
+        # Keep track of beam major axis and pixel sizes
+        bmaj_list = []
+        pix_list = []
+
+        for this_infile in infile_list:
+            logger.info(f"Checking {this_infile}")
+
+            cube = SpectralCube.read(this_infile)
+
+            pixel_scales = proj_plane_pixel_scales(cube.wcs.celestial) * u.deg
+            pixel_as = [p for p in pixel_scales][0]
+
+            bmaj = cube.beam.major
+
+            bmaj_list.append(bmaj.to(u.arcsec).value)
+            pix_list.append(pixel_as.to(u.arcsec).value)
+
+        max_bmaj = np.max(bmaj_list)
+        max_pix = np.max(pix_list)
+        target_bmaj = np.sqrt(max_bmaj**2 + (pixel_padding * max_pix) ** 2) * u.arcsec
+
+        # Ensure we just have a single quantity value here
+        if not isinstance(target_bmaj, u.Quantity):
+            raise TypeError(f"target_bmaj must be a Quantity, not {type(target_bmaj)}")
+
+    else:
+        target_bmaj = target_res * u.arcsec
+
+    logger.info(f"Found a common beam size of {str(target_bmaj)}")
+
+    if not do_convolve:
+        return target_bmaj.value
+
+    # Build a target beam
+    target_beam = Beam(major=target_bmaj, minor=target_bmaj, pa=0 * u.deg)
+
+    # Convolve each cube to the target beam
+    for this_infile in infile_list:
+        this_outfile = outfile_dict[this_infile]
+
+        if os.path.exists(this_outfile) and not overwrite:
+            logger.info(
+                f"{this_outfile} already exists and overwrite is False. Will not overwrite."
+            )
+            continue
+
+        logger.info(
+            f"Convolving {os.path.basename(this_infile)} to {os.path.basename(this_outfile)}"
+        )
+
+        cube = SpectralCube.read(this_infile)
+        cube.allow_huge_operations = True
+
+        if convolve_fn == "convolve":
+            conv_fn = convolve
+        elif convolve_fn == "convolve_fft":
+            conv_fn = convolve_fft
+        else:
+            raise ValueError(f"convolve_fn {convolve_fn} not recognized")
+
+        kwargs = {
+            "nan_treatment": nan_treatment,
+            "preserve_nan": True,
+        }
+
+        # Keep track of the original dtype since it can change during convolution
+        orig_dtype = cube.unmasked_data[0, 0, 0].dtype
+
+        cube = cube.convolve_to(
+            target_beam,
+            convolve=conv_fn,
+            **kwargs,
+        )
+
+        cube_dtype = cube.unmasked_data[0, 0, 0].dtype
+
+        # If dtype has changed, recreate the cube
+        if cube_dtype != orig_dtype:
+
+            # Do this channel by channel to avoid needing a lot of RAM
+            create_large_fits(
+                this_outfile,
+                cube.header,
+            )
+
+            with fits.open(this_outfile, mode="update") as hdu:
+                n_chan = hdu[0].data.shape[0]
+
+                logger.info("Writing cube out channel-by-channel")
+                with ProgressBar(n_chan) as bar:
+                    for chan in range(n_chan):
+                        hdu[0].data[chan] = cube.unitless_filled_data[chan].astype(orig_dtype)
+                        hdu.flush()
+                        bar.update()
+
+        else:
+            cube.write(
+                this_outfile,
+                overwrite=True,
+            )
+
+    return target_bmaj.value
+
+
+def sample_array_edges(
+    shape: np.ndarray,
+    *,
+    n_samples: int,
+):
+    """
+    Get edges from an array
+
+    Given an N-dimensional array shape, sample each edge of the array using
+    the requested number of samples (which will include vertices). To do this
+    we iterate through the dimensions and for each one we sample the points
+    in that dimension and iterate over the combination of other vertices.
+    Returns an array with dimensions (N, n_samples)
+
+    Args:
+        shape (np.ndarray): The shape of the array to sample
+        n_samples (int): The number of samples to take
+    """
+
+    all_positions = []
+    ndim = len(shape)
+    shape = np.array(shape)
+    for idim in range(ndim):
+        for vertex in range(2**ndim):
+            positions = -0.5 + shape * ((vertex & (2 ** np.arange(ndim))) > 0).astype(int)
+            positions = np.broadcast_to(positions, (n_samples, ndim)).copy()
+            positions[:, idim] = np.linspace(-0.5, shape[idim] - 0.5, n_samples)
+            all_positions.append(positions)
+    positions = np.unique(np.vstack(all_positions), axis=0).T
+    return positions
+
+
+def common_grid_for_mosaic(
+    infile_list: list | None = None,
+    outfile_list: list | dict | None = None,
+    template_name: str | None = None,
+    target_hdr: fits.Header | None = None,
+    allow_big_image: bool = False,
+    too_big_pix: int | float = 1e4,
+    overwrite: bool = False,
+):
+    """
+    Build a common astrometry for a mosaic and align all input image
+    files to that astrometry. If the common astrometry isn't supplied
+    as a header, the program calls other routines to create it based
+    on the supplied parameters and stack of input images. Returns the
+    common header.
+
+    Args:
+        infile_list (list|None): a list of input image files.
+        outfile_list (list|dict|None): a list or dictionary of output image files.
+        template_name (str): Name format for the output template cubes that
+            will define the final mosaic.
+        target_hdr (fits.Header): User-provided header. Defaults to None,
+            which will build an optimal header
+        allow_big_image (bool, optional): If True, allow big images to be created.
+            Defaults to False.
+        too_big_pix (int|float, optional): The threshold for what constitutes a "big"
+            image in pixels. Defaults to 1e4.
+        overwrite (bool): Whether to overwrite existing images. Defaults to False.
+
+    Returns:
+        fits.Header: Target common header
+    """
+
+    if infile_list is None:
+        logger.error("Infile list missing.")
+        return None
+
+    if len(infile_list) == 0:
+        logger.error("No files to process.")
+        return None
+
+    for this_infile in infile_list:
+        if not os.path.exists(this_infile):
+            logger.error(f"File {this_infile} not found. Continuing.")
+            continue
+
+    if outfile_list is None:
+        logger.error("Outfile list missing.")
+        return None
+
+    if template_name is None:
+        logger.error("Need to supply a template name.")
+        return None
+
+    # Make sure that the outfile list is a dictionary
+    if not isinstance(outfile_list, list) and not isinstance(outfile_list, dict):
+        logger.error("outfile_list must be dictionary or list.")
+        return None
+
+    outfile_dict = {}
+    if isinstance(outfile_list, list):
+        if len(infile_list) != len(outfile_list):
+            logger.error("Mismatch in input and output list lengths.")
+            return None
+
+        outfile_dict = {}
+        for ii in range(len(infile_list)):
+            outfile_dict[infile_list[ii]] = outfile_list[ii]
+
+    if isinstance(outfile_list, dict):
+        outfile_dict = outfile_list
+
+    # Get the common header if one is not supplied
+    if target_hdr is None:
+        logger.info("Generating target header.")
+
+        target_hdr = build_common_header(
+            infile_list=infile_list,
+            allow_big_image=allow_big_image,
+            too_big_pix=too_big_pix,
+        )
+
+    if target_hdr is None:
+        logger.error("No target header, and was not able to build one.")
+        return None
+
+    # Create three template headers: one for flux, one for weight, one for mask.
+    # They're the same thing, but with different units and dtypes
+    logger.info("Creating template headers for flux, weight, and mask.")
+
+    unitless_hdr = copy.deepcopy(target_hdr)
+    unitless_hdr.pop("BUNIT", None)
+
+    mask_hdr = copy.deepcopy(target_hdr)
+    mask_hdr.update({"BITPIX": 8})
+
+    target_hdr.totextfile(template_name.replace(".fits", "_flux.txt"), overwrite=True)
+    unitless_hdr.totextfile(template_name.replace(".fits", "_weight.txt"), overwrite=True)
+    mask_hdr.totextfile(template_name.replace(".fits", "_mask.txt"), overwrite=True)
+
+    # Align the input files to the new astrometry. This will also loop
+    # over and align any "weight" files.
+    logger.info("Aligning image files")
+
+    for this_infile in infile_list:
+        this_outfile = outfile_dict[this_infile]
+
+        if os.path.exists(this_outfile) and not overwrite:
+            logger.info(
+                f"{os.path.basename(this_outfile)} already exists and overwrite is False. Will not overwrite."
+            )
+            continue
+
+        logger.info(
+            f"Reprojecting {os.path.basename(this_infile)} to {os.path.basename(this_outfile)}"
+        )
+
+        # Get the spectral axis out from the target header
+        w = WCS(target_hdr)
+
+        cube = SpectralCube.read(this_infile)
+
+        # We start by doing a reproject to the minimal size to slot
+        # the array neatly into an output array. Do this in 2D
+        w_2d = w[0, :, :]
+        cube_w_2d = cube.wcs[0, :, :]
+
+        edges = sample_array_edges(cube.shape[1:], n_samples=11)[::-1]
+        edges_out = w_2d.world_to_pixel(cube_w_2d.pixel_to_world(*edges))[::-1]
+
+        # Determine the cutout parameters
+
+        # In some cases, images might not have valid coordinates in the corners,
+        # such as all-sky images or full solar disk views. In this case we skip
+        # this step and just use the full output WCS for reprojection.
+        optimal_shape = w.array_shape[1:]
+        ndim_out = len(optimal_shape)
+
+        skip_data = False
+        if np.any(np.isnan(edges_out)):
+            bounds = list(zip([0] * ndim_out, optimal_shape))
+        else:
+            bounds = []
+            for idim in range(ndim_out):
+                imin = max(0, int(np.floor(edges_out[idim].min() + 0.5)))
+                imax = min(optimal_shape[idim], int(np.ceil(edges_out[idim].max() + 0.5)))
+                bounds.append((imin, imax))
+                if imax < imin:
+                    skip_data = True
+                    break
+
+        if skip_data:
+            raise Exception("Could not force cube into optimal header!")
+
+        bounds_as_slice = tuple([slice(b[0], b[1]) for b in bounds])
+        slice_out = tuple([slice(imin, imax) for (imin, imax) in bounds])
+
+        # Slice out the part of the WCS we care about, and do the reprojection
+        indiv_w = w[:, *slice_out]
+
+        cube = reproject_to_other_wcs(
+            cube=cube,
+            wcs=indiv_w,
+        )
+
+        # And we also need to write out the details for the slice, so we can put this back into the view
+        # later
+        with open(this_outfile.replace(".fits", "_slice.txt"), "w+") as f:
+            f.write(str(slice_out))
+
+        cube.write(this_outfile, overwrite=True)
+
+    return target_hdr
+
+
+def noise_for_cube(
+    infile: str | None = None,
+    maskfile: str | None = None,
+    exclude_mask: bool = True,
+):
+    """
+    Get a single noise estimate for an image cube.
+
+    TODO: maskfile functionality has not been tested
+
+    Args:
+        infile (str | None): the input image file.
+        maskfile (str | None): the mask image file.
+        exclude_mask (default True): if True, mask is excluded.
+            Defaults to True.
+
+    Returns:
+        float: Noise value
+    """
+
+    if infile is None:
+        logger.error("No infile specified.")
+        return None
+
+    if not os.path.exists(infile):
+        logger.error(f"infile specified but not found - {infile}")
+        return None
+
+    if maskfile is not None:
+        if not os.path.exists(maskfile):
+            logger.error(f"maskfile specified but not found - {maskfile}")
+            return None
+
+    # Read in cubes
+    cube = SpectralCube.read(infile)
+    cube.allow_huge_operations = True
+
+    if maskfile is not None:
+        mask = SpectralCube.read(maskfile)
+        mask.allow_huge_operations = True
+        mask.with_fill_value(0)
+
+        mask = mask.filled_data[:].astype(bool)
+
+        # If the mask is not an exclude, then flip the signs
+        if not exclude_mask:
+            mask = ~mask
+
+    else:
+        mask = None
+
+    this_noise = mad_zero_centered(
+        data=cube.unitless_filled_data[:],
+        mask=mask,
+    )
+
+    return this_noise
+
+
+def generate_weight_file(
+    image_file: str | None = None,
+    input_file: str | None = None,
+    input_value: float | int | None = None,
+    input_type: str = "pb",
+    outfile: str | None = None,
+    scale_by_noise: bool = False,
+    mask_for_noise: str | None = None,
+    noise_value: float | None = None,
+    scale_by_factor: float | None = None,
+    overwrite: bool = False,
+):
+    """
+    Generate a weight image for use in a linear mosaic.
+
+    The weight image will be used in the linear mosaicking as a weight,
+    multiplied by the image file and then divided out. The optimal S/N
+    choice is often 1/noise^2. The program gives some options to
+    calculate a weight image of this type from the data or using the
+    primary beam response.
+
+    Args:
+        image_file (str | None): the input image file
+        input_file (str | None): the input file for weight calculation
+        input_value (float | int | None): the input value for weight calculation
+        input_type (str): the type of input. Should be one of
+            - 'pb' for primary beam response (weight goes at pb^2)
+            - 'noise' for a noise estimate (weight goes as 1/noise^2)
+            - 'weight' for a weight value
+        outfile (str | None): the output weight file
+        scale_by_noise (bool): whether to scale by 1/noise^2
+        mask_for_noise (str | None): the mask for noise calculation
+        noise_value (float | None): the noise value in the image.
+            If not supplied, the program will calculate it from the image.
+        scale_by_factor (float | None): the factor to scale by
+        overwrite (bool): whether to overwrite existing files
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+
+    # Check input
+    if image_file is None and input_file is None:
+        logger.error("I need either an input or an image template file.")
+        return False
+
+    if input_file is None and input_value is None:
+        logger.error("I need either an input value or an input file.")
+        return False
+
+    if input_file is not None and input_value is not None:
+        logger.error("I need ONE OF an input value or an input file. Got both.")
+        return False
+
+    if outfile is None:
+        logger.error("Specify output file.")
+        return False
+
+    if input_file is not None:
+        valid_types = ["pb", "noise", "weight"]
+        if input_type not in valid_types:
+            logger.error(f"Valid input types are : {valid_types}")
+            return False
+
+    if input_file is None and input_value is None:
+        logger.error("Need either an input value or an input file.")
+        return False
+
+    if input_file is not None:
+        if not os.path.exists(input_file):
+            logger.error(f"Missing input file directory - {input_file}")
+            return False
+
+    if image_file is not None:
+        if not os.path.exists(image_file):
+            logger.error(f"Missing image file directory - {image_file}")
+            return False
+
+    if not overwrite and os.path.exists(outfile):
+        logger.info(f"{outfile} exists and overwrite is False. Skipping")
+        return True
+
+    # If scaling by noise is requested and no estimate is provided,
+    # generate an estimate
+
+    if scale_by_noise:
+        if noise_value is None and image_file is None:
+            logger.error("I can only scale by the noise if I have a noise value or an image.")
+            return False
+
+        if noise_value is None:
+            logger.info(f"Calculating noise for {image_file}")
+
+            noise_value = noise_for_cube(
+                infile=image_file,
+                maskfile=mask_for_noise,
+                exclude_mask=True,
+            )
+            if np.isnan(noise_value):
+                raise ValueError("Could not calculate noise")
+
+            logger.info(f"Noise: {noise_value}")
+
+    # Define the template for the astrometry
+    template = copy.deepcopy(input_file)
+    if template is None:
+        template = copy.deepcopy(image_file)
+
+    logger.debug(f"Template for weight file is: {template}")
+
+    data = SpectralCube.read(template)
+    data.allow_huge_operations = True
+    weight = SpectralCube.read(template)
+    weight.allow_huge_operations = True
+
+    # Case 1 : We just have an input value
+    if input_file is None and input_value is not None:
+        weight_value = get_weight_value(
+            input_type=input_type,
+            input_value=input_value,
+            scale_by_factor=scale_by_factor,
+            scale_by_noise=scale_by_noise,
+            noise_value=noise_value,
+        )
+
+        # Make sure we end up unitless
+        weight = weight / weight * weight_value
+
+    # Case 2 : We have an input image. Manipulate data into a weight
+    # array
+    if input_file is not None:
+        weight = get_weight_value(
+            input_type=input_type,
+            input_value=data,
+            scale_by_factor=scale_by_factor,
+            scale_by_noise=scale_by_noise,
+            noise_value=noise_value,
+        )
+
+        if not isinstance(weight, SpectralCube):
+            raise TypeError("weight should be a SpectralCube object")
+
+    weight.write(outfile, overwrite=True)
+
+    return True
+
+
+def get_weight_value(
+    input_type: str = "pb",
+    input_value: float | int | None = None,
+    scale_by_factor: float | int | None = None,
+    scale_by_noise: bool = False,
+    noise_value: float | int | None = None,
+):
+    """Get weight value, given specific input types and values
+
+    Args:
+        input_type: the type of input. This can be
+            - 'pb' for primary beam response (weight goes at pb^2)
+            - 'noise' for a noise estimate (weight goes as 1/noise^2)
+            - 'weight' for a weight value
+        input_value: an input value of some type (see below) used to form
+            the basis for the weight. This is a single value. Only one of
+            input_file or input_value can be set.
+        scale_by_factor: a factor to scale the weight
+        scale_by_noise: scale the weight by noise? Defaults to False
+        noise_value: the value to use for noise
+
+    Returns:
+        float|SpectralCube: The calculated weight value
+    """
+
+    if input_value is None:
+        raise ValueError("Need an input value")
+
+    if input_type == "noise":
+        weight = 1.0 / input_value**2
+    elif input_type == "pb":
+        weight = input_value**2
+    elif input_type == "weight":
+        weight = input_value
+    else:
+        raise ValueError(f"Unknown input type: {input_type}")
+
+    # Apply scaling
+    if scale_by_factor is not None:
+        weight *= scale_by_factor
+    if scale_by_noise:
+        if noise_value is None:
+            raise ValueError("If scaling by noise, then noise value should be defined")
+
+        weight /= noise_value**2
+
+    return weight
+
+
+def mosaic_aligned_data(
+    infile_list: list | None = None,
+    weightfile_list: list | dict | None = None,
+    template_name: str | None = None,
+    outfile: str | None = None,
+    overwrite: bool = False,
+):
+    """
+    Combine a list of previously aligned data into a single image
+    using linear mosaicking. Weight each file using a corresponding
+    weight file and also create sum and integrated weight files.
+
+    Args:
+        infile_list (list). List of input files
+        weightfile_list (list|dict). List of weight files. Can be a
+            dictionary or a list. If it's a list then
+            matching is by order, so that the first infile goes to first
+            weight file, etc. If it's a dictionary, it looks for the infile
+            name as a key.
+        template_name (str): Name for the path to template cubes for the
+            mosaic.
+        outfile (str). The name of the output mosaic image.
+        overwrite (bool, optional) : Delete existing files.
+            Defaults to False
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+
+    # Check inputs
+    if infile_list is None:
+        logger.error("Input file list required.")
+        return False
+
+    if len(infile_list) == 0:
+        logger.error("No files to process.")
+        return False
+
+    if weightfile_list is None:
+        logger.error("Missing weightfile_list required for mosaicking.")
+        return False
+
+    if template_name is None:
+        logger.error("Missing template_name required for mosaicking.")
+        return False
+
+    if outfile is None:
+        logger.error("Output file is required.")
+        return False
+
+    # Define some extra outputs and then check file existence
+    sum_file = outfile.replace(".fits", ".sum.fits")
+    weight_file = outfile.replace(".fits", ".weight.fits")
+    mask_file = outfile.replace(".fits", ".mask.fits")
+
+    for this_file in [outfile, sum_file, weight_file, mask_file]:
+        if os.path.exists(this_file) and not overwrite:
+            logger.error(
+                f"Output file {this_file} present and overwrite False. Will not create mosaic"
+            )
+            return False
+
+    # Get the weight file list together
+    if not isinstance(weightfile_list, list) and not isinstance(weightfile_list, dict):
+        logger.error("Weightfile_list must be dictionary or list.")
+        return False
+
+    weightfile_dict = {}
+    if isinstance(weightfile_list, list):
+        if len(infile_list) != len(weightfile_list):
+            logger.error("Mismatch in input and output list lengths.")
+            return False
+
+        for ii in range(len(infile_list)):
+            weightfile_dict[infile_list[ii]] = weightfile_list[ii]
+
+    if isinstance(weightfile_list, dict):
+        weightfile_dict = weightfile_list
+
+    # And get out slice indices for viewing the subcube in the full mosaic
+    slice_dict = {}
+    for this_infile in infile_list:
+        slice_dict[this_infile] = this_infile.replace(".fits", "_slice.txt")
+
+    # Check file existence
+    for this_infile in infile_list:
+        if not os.path.exists(this_infile):
+            logger.error(f"Missing file - {this_infile}")
+            return False
+
+        this_weightfile = weightfile_dict[this_infile]
+        if not os.path.exists(this_weightfile):
+            logger.error(f"Missing file - {this_weightfile}")
+            return False
+
+        this_slice = slice_dict[this_infile]
+        if not os.path.exists(this_slice):
+            logger.error(f"Missing file - {this_slice}")
+            return False
+
+    # Now, we do the mosaicking! Build empty files from template headers
+    template_flux_header_file = template_name.replace(".fits", "_flux.txt")
+    template_flux_header = fits.Header.fromtextfile(template_flux_header_file)
+
+    template_weight_header_file = template_name.replace(".fits", "_weight.txt")
+    template_weight_header = fits.Header.fromtextfile(template_weight_header_file)
+
+    template_mask_header_file = template_name.replace(".fits", "_mask.txt")
+    template_mask_header = fits.Header.fromtextfile(template_mask_header_file)
+
+    create_large_fits(
+        f=sum_file,
+        header=template_flux_header,
+    )
+    create_large_fits(
+        f=weight_file,
+        header=template_weight_header,
+    )
+    create_large_fits(
+        f=mask_file,
+        header=template_mask_header,
+    )
+    create_large_fits(
+        f=outfile,
+        header=template_flux_header,
+    )
+
+    # Load in all the cubes and slices. Use a fill value of 0
+    infile_cubes = []
+    weightfile_cubes = []
+    slices = []
+
+    for this_infile in infile_list:
+        this_weightfile = weightfile_dict[this_infile]
+        this_slice = slice_dict[this_infile]
+
+        cube = SpectralCube.read(this_infile)
+        cube.allow_huge_operations = True
+        cube = cube.with_fill_value(0)
+
+        infile_cubes.append(cube)
+
+        weight_cube = SpectralCube.read(this_weightfile)
+        weight_cube.allow_huge_operations = True
+        weight_cube = weight_cube.with_fill_value(0)
+
+        weightfile_cubes.append(weight_cube)
+
+        with open(this_slice, "r") as f:
+            slice_str = f.read()
+            slice_tuple = eval(slice_str)
+            slices.append(list(slice_tuple))
+
+    # Perform the various calculations. We do this channel-by-channel to minimize RAM requirements
+    with (
+        fits.open(sum_file, mode="update") as sum_hdu,
+        fits.open(weight_file, mode="update") as weight_hdu,
+        fits.open(mask_file, mode="update") as mask_hdu,
+        fits.open(outfile, mode="update") as out_hdu,
+    ):
+        n_chan = sum_hdu[0].data.shape[0]
+
+        # Make sure we have the beam and units right, and if not replace them
+        for hdu in [sum_hdu, weight_hdu, mask_hdu, out_hdu]:
+
+            keys_to_update = [
+                "BMAJ",
+                "BMIN",
+                "BPA",
+                "BEAM",
+                "BUNIT",
+            ]
+
+            for key in keys_to_update:
+
+                if key in hdu[0].header:
+                    if hdu[0].header[key] != infile_cubes[0].header[key]:
+                        hdu[0].header[key] = infile_cubes[0].header[key]
+
+            hdu.flush()
+
+        logger.info("Processing mosiac channel-by-channel")
+
+        with ProgressBar(n_chan) as bar:
+            # Loop over each channel
+            for chan in range(n_chan):
+                # Pull out the channel from the cube
+                sum_hdu_idx = sum_hdu[0].data[chan]
+                weight_hdu_idx = weight_hdu[0].data[chan]
+
+                # Loop over each input cube
+                for cube_idx in range(len(infile_cubes)):
+                    slice_idx = slices[cube_idx]
+                    flux_idx = infile_cubes[cube_idx]
+                    weight_idx = weightfile_cubes[cube_idx]
+
+                    # For the slice this cube corresponds to, calculate weighted sum and weight
+                    sum_hdu_idx[*slice_idx] += (
+                        flux_idx.unitless_filled_data[chan] * weight_idx.unitless_filled_data[chan]
+                    )
+                    weight_hdu_idx[*slice_idx] += weight_idx.unitless_filled_data[chan]
+
+                # Put NaNs back in
+                sum_hdu_idx[sum_hdu_idx == 0] = np.nan
+
+                # Get the mask out as anywhere we've got weight
+                mask_hdu_idx = weight_hdu_idx != 0
+                mask_hdu_idx = mask_hdu_idx.astype(np.uint8)
+
+                # Calculate the overall mosaic by dividing the sum by the weight
+                out_hdu_idx = sum_hdu_idx / weight_hdu_idx
+
+                # Put channels back into cube
+                sum_hdu[0].data[chan] = copy.deepcopy(sum_hdu_idx)
+                weight_hdu[0].data[chan] = copy.deepcopy(weight_hdu_idx)
+                mask_hdu[0].data[chan] = copy.deepcopy(mask_hdu_idx)
+                out_hdu[0].data[chan] = copy.deepcopy(out_hdu_idx)
+
+                # Save out changes to disk
+                sum_hdu.flush()
+                weight_hdu.flush()
+                mask_hdu.flush()
+                out_hdu.flush()
+
+                bar.update()
+
+    return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,11 @@ dependencies = [
     "numpy >= 2.3.5",
     "protobuf == 3.20",
     "pytz >= 2025.2",
+    "radio-beam >= 0.3.9",
+    "reproject >= 0.21.0",
     "scipy >= 1.16.3",
     "spectral-cube >= 0.6.7",
+    "uvcombine@git+https://github.com/radio-astro-tools/uvcombine.git",
 ]
 
 # Optional packages for CASA


### PR DESCRIPTION
**TL;DR: Stick `postprocessing_method="spectralcube"` into the `loop_postprocessing` call, enjoy much faster postprocessing.**

Fixes #369.

This PR removes the need for CASA in postprocessing. It uses radio-beam, reproject, spectral-cube, and uvcombine. The bonus of this is that keeping track of axes is now significantly easier, the code is much tidier, and we're generally faster since we don't need to fall back to large cube workarounds. There are some plots below that show regression tests between all of the functions, and I've also checked that the fits files output at the end are comparable in all cases.

Adds 3 main new files, scCubeRoutines, scFeatherRoutines, and scMosaicRoutines. These are mostly equivalent replacements for the CASA equivalents, and have mostly the same arguments. They generally use .fits files, aside from the initial `trim_cube` call.

For now, we keep the CASA versions as the defaults, but you can switch by adding `postprocessing_method="spectralcube"` into the `loop_postprocessing` call. I suggest that at some point we deprecate the CASA routines in favour of these, since they appear to be comparable in my test cases and are significantly simpler to extend and faster.

**Notable function changes:**

- In noise calculations, we now use `scNoiseRoutines.mad_zero_centered`. This cleans up the code, but does remove a bit of functionality.
- In `align_to_target`, we drop the interpolation order for the reprojection. Changing this can cause crashes in the astropy reproject routine, so we do not expose this
- `convert_jytok` and `convert_ktoj` have been merged into a general function `convert_units` where the units can be passed along as a string or astropy.units
- `build_common_header` is now significantly simplified, and does not take overrides for `ra_ctr`, `dec_ctr`, `delta_ra` or `delta_dec`. These aren't actually passed through in the pipeline, so functionally this is the same
- `common_grid_for_mosaic` will reproject to the common grid but extract a minimal sub-cube, to lower disk requirements, as well as put out a text file indicating the (x, y) slice the subcube equates to in the full mosaic
- Mosaicking is done channel-by-channel, to lower memory cost. 
- Any reprojections are done channel-by-channel, to lower memory cost. This should be what spectral-cube does under the hood, but for whatever reason doing it explicitly is much more RAM-efficient

**Function regressions:**

Here are plots for the various functions. Left is the "worst slice" of the cube as defined by maximum absolute sum of the difference between CASA/spectral-cube, and right shows the difference and data, with 1/99th percentile spreads. They look pretty good! With the exception of some edge effects that appear with convolution. Note these plots aren't in order of when they actually happen in the pipeline.

<img width="785" height="411" alt="convert_jytok" src="https://github.com/user-attachments/assets/0cf9a977-f36d-47f2-b4c3-5593e142a5fe" />
<img width="785" height="411" alt="convolve_to_round_beam" src="https://github.com/user-attachments/assets/d02c6806-1907-46fd-9fc1-9d483faa8d4e" />
<img width="773" height="411" alt="feather_two_cubes" src="https://github.com/user-attachments/assets/6e11407e-a013-4e2c-b0fa-1afa51204523" />
<img width="759" height="411" alt="generate_weight_file" src="https://github.com/user-attachments/assets/9e37ef85-33df-4a0c-a80f-ee3a060e1afa" />
<img width="785" height="411" alt="linmos_aligned" src="https://github.com/user-attachments/assets/6d8a4bcc-fc4f-4094-8672-14d1dd44e89f" />
<img width="785" height="411" alt="linmos_commonres" src="https://github.com/user-attachments/assets/49de7f44-3d3f-45aa-9064-b3a1700a60ba" />
<img width="785" height="411" alt="mosaicked" src="https://github.com/user-attachments/assets/37b64c96-9e4e-41dc-8e37-9046dae41866" />
<img width="760" height="411" alt="prep_sd_for_feather" src="https://github.com/user-attachments/assets/e126484b-585a-4b6e-8472-1c32ce82dbaa" />
<img width="754" height="411" alt="primary_beam_correct" src="https://github.com/user-attachments/assets/53a3b5c0-62a6-4805-9c5f-251dcaae37ef" />
<img width="785" height="411" alt="trim_cube_rebin" src="https://github.com/user-attachments/assets/42863097-1246-4899-8a2c-bce35b57fb31" />
<img width="754" height="411" alt="trim_cube" src="https://github.com/user-attachments/assets/5b056a4b-b4e9-420c-a0b6-f1f89e915cbc" />
<img width="777" height="411" alt="weight_aligned" src="https://github.com/user-attachments/assets/7ad8c353-143f-423f-8511-7a784ba185a6" />

**Speed differences:**

These are listed as casa/spectral-cube, and were tested for one of the 7m NGC5236 mosaics (_1). Note that these should should be best cases for CASA, and when dealing with big cubes spectral-cube should win out more significantly since we don't have to do costly plane-by-plane calculations

- `trim_cube` (no rebin): 2s/2s
- `primary_beam_correct`: 1.5s/0.5s
- `convolve_to_round_beam`: 102s/2s
- `prep_sd_for_feather`: 4s/14s
- `generate_weight_file`: 2.8s/3.5s
- `feather_two_cubes`: 17.8s/6s
- `trim_cube` (rebin): 4s/0.6s
- `align_to_target`: 0.8s/3.4s
- `convert_jytok`: 0.68s/0.23s
- `export_and_cleanup`: 5.1s/1.32s

For mosaic-related functions, I tested times using 2 of the NGC5236 tiles (_1 and _2)

- `common_res_for_mosaic`: 155.9s/3.75s
- `common_grid_for_mosaic`: 46.36s/119s
- `mosaic_aligned_data`: 22.7s/7.9s

Ran the full NGC5236 7m and 7m+TP mosaics for a "real-world" test case. Overall speed up moving away from CASA: ~3x (3966s/1392s)

Tested the NGC5236 12m+7m+tp case, for a large cube check. Overall speed up moving away from CASA: ~2x (336551s/178217s)

Note that this also leaves a smaller disk footprint: For the 7m run, it's a factor of 3 (25GB vs 9GB). For the 12m+7m+tp, it's a factor 2 (2.4TB vs 1.1TB). Most of this comes from the mosaicking no longer requiring reprojection to a full grid, plus not keeping interchangeable .image and .fits files around at the final export step.

**Branches not explicitly tested:**

I've tested this runs end-to-end with the pipeline defaults. There are some potential edge cases that have no been explicitly tested so we need to keep an eye on them. I think this is the full list:

- apodization in `feather_two_cubes`
- `trim_rind` not tested. Is not used in the default pipeline since an output file is never defined

**Overview of changes:**

*handlerPostprocess*

- Removed trim_coarse_beam_edge_channels, since this is now handled upstream
- Removed unused `recipe_convolve_to_scale`
- `task_rename_sdintimaging` is now spectral-cube postprocessing-aware

*scCubeRoutines*

- Added spectral-cube equivalent for `export_and_cleanup`
- Added spectral-cube equivalent for `convolve_to_round_beam`
- Added spectral-cube equivalent of `align_to_target`
- Added spectral-cube equivalent for `primary_beam_correct`
- Added spectral-cube equivalent for `trim_cube`
- Added spectral-cube equivalent of `trim_rind`
- Added spectral-cube equivalents for `convert_jtok` and `convert_ktojy`: `convert_units`

*scFeatherRoutines*

- Added spectral-cube equivalent for `prep_sd_for_feather`
- Added uvcombine equivalent for `feather_two_cubes`

*scMosaicRoutines*

- Added reproject equivalent for `build_common_header`
- Added spectral-cube equivalent for `common_res_for_mosaic`
- Added spectral-cube equivalent for `common_grid_for_mosaic`
- Added spectral-cube equivalent for `generate_weight_file`, which also includes a new, simplified noise calculation routine
- Added spectral-cube equivalent for `mosaic_aligned_data`

*Others*

- Added radio-beam requirement to pyproject.toml
- Added reproject requirement to pyproject.toml
- Added uvcombine requirement to pyproject.toml
- Update docs
