### PR TITLE
Speedup for sdintimaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add tests for utilsLines, and tidy up formatting (#363).
 - Added spectral-cube equivalent routines for postprocessing (#371).
 - Add tests for scMoments, and tidy up formatting (#389).
+- Speed up sdintimaging by replacing feather with custom uvcombine tasks (#376).
 
 ### Changed
 
@@ -29,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated bespoke sdintimaging task, to align with latest CASA version (#347).
 - If we don't have any model flux, then overwrite minimum number of major cycles (#359).
 - Keep all 4 axes throughout postprocessing, to avoid slowdowns with re-adding degenerate axes (#353).
+- Speed up sdintimaging by removing unneeded repeated slow operations (#376).
 
 ### Fixed
 

--- a/phangsPipeline/taskSDIntImaging.py
+++ b/phangsPipeline/taskSDIntImaging.py
@@ -23,6 +23,8 @@ from casatools import table
 from casatasks import imstat
 from casatools import synthesisimager,synthesisutils
 
+from .utilsSDIntImaging import feather_int_sd, feather_residual
+
 try:
     from casampi.MPIEnvironment import MPIEnvironment
     from casampi import MPIInterface
@@ -117,7 +119,12 @@ def setup_imager(imagename, specmode,calcres,calpsf,inparams):
 
     return imagertool
 
-def setup_deconvolver(imagename,specmode,inparams):
+def setup_deconvolver(imagename,
+                      specmode,
+                      calcpsf,
+                      calcres,
+                      inparams,
+                      ):
     """
     Cube or MFS minor cycles. 
     """
@@ -130,20 +137,28 @@ def setup_deconvolver(imagename,specmode,inparams):
     deconvolvertool.initializeNormalizers()
     deconvolvertool.setWeighting()
 
+    ### These three should be unncessary.  Need a 'makeimage' method for csys generation.
+    if calcpsf:
+        deconvolvertool.makePSF()  ## Make this to get a coordinate system
+        #deconvolvertool.makeImage('psf', imagename+'.psf')
+        deconvolvertool.makePB()  ## Make this to turn .weight into .pb maps
 
-    ### These three should be unncessary.  Need a 'makeimage' method for csys generation. 
-    deconvolvertool.makePSF() ## Make this to get a coordinate system
-    #deconvolvertool.makeImage('psf', imagename+'.psf')
-    deconvolvertool.makePB()  ## Make this to turn .weight into .pb maps
-
-        ## Initialize deconvolvers. ( Order is important. This cleans up a leftover tablecache image.... FIX!)
+    ## Initialize deconvolvers. ( Order is important. This cleans up a leftover tablecache image.... FIX!)
     deconvolvertool.initializeDeconvolvers()
     deconvolvertool.initializeIterationControl() # This needs to be run before runMajorCycle
-    deconvolvertool.runMajorCycle(isCleanCycle=False) ## Make this to make template residual images.
+
+    if calcres:
+        deconvolvertool.runMajorCycle(isCleanCycle=False) ## Make this to make template residual images.
  
     return deconvolvertool
 
-def setup_sdimaging(template='',output='', inparms=None, sdparms=None):
+def setup_sdimaging(template='',
+                    output='',
+                    calcpsf=True,
+                    calcres=True,
+                    inparms=None,
+                    sdparms=None,
+                    ):
     """
     Make the SD cube Image and PSF
 
@@ -165,28 +180,30 @@ def setup_sdimaging(template='',output='', inparms=None, sdparms=None):
         raise RuntimeError("Internal Error: missing sdimage parameter") 
     if 'pblimit' in inparms:
         pblimit = inparms['pblimit']
+        
+    if calcres:
+        ## Regrid the input SD image to the target coordinate system.
+        sdintlib.regridimage(imagename=sdimage, template=template+'.residual', outfile=output+'.residual')
+        sdintlib.regridimage(imagename=sdimage, template=template+'.residual', outfile=output+'.image')
+    
+        ## Apply the pbmask from the INT image cube, to the SD cubes.
+        #TTB: Create *.mask cube  
+    
+        sdintlib.addmask(inpimage=output+'.residual', pbimage=template+'.pb', pblimit=pblimit)
+        sdintlib.addmask(inpimage=output+'.image', pbimage=template+'.pb', pblimit=pblimit)
 
-    if sdpsf !="":
-        ## check the coordinates of psf with int psf
-        sdintlib.checkpsf(sdpsf, template+'.psf') 
-
-    ## Regrid the input SD image and PSF cubes to the target coordinate system. 
-    sdintlib.regridimage(imagename=sdimage, template=template+'.residual', outfile=output+'.residual')
-    sdintlib.regridimage(imagename=sdimage, template=template+'.residual', outfile=output+'.image')
-
-    if sdpsf !="":
-        sdintlib.regridimage(imagename=sdpsf, template=template+'.psf', outfile=output+'.psf')
-    else:
-        ## Make an internal sdpsf image if the user has not supplied one. 
-        casalog.post("Constructing a SD PSF cube by evaluating Gaussians based on the restoring beam information in the regridded SD Image Cube")
-        sdintlib.create_sd_psf(sdimage=output+'.residual', sdpsfname=output+'.psf')
-
-    ## Apply the pbmask from the INT image cube, to the SD cubes.
-    #TTB: Create *.mask cube  
-
-    sdintlib.addmask(inpimage=output+'.residual', pbimage=template+'.pb', pblimit=pblimit)
-    sdintlib.addmask(inpimage=output+'.image', pbimage=template+'.pb', pblimit=pblimit)
-
+    if calcpsf:
+        if sdpsf != "":
+            ## check the coordinates of psf with int psf
+            sdintlib.checkpsf(sdpsf, template + ".psf")
+        if sdpsf !="":
+            ## Regrid the input PSF cube to the target coordinate system.
+            sdintlib.regridimage(imagename=sdpsf, template=template+'.psf', outfile=output+'.psf')
+        else:
+            ## Make an internal sdpsf image if the user has not supplied one.
+            casalog.post("Constructing a SD PSF cube by evaluating Gaussians based on the restoring beam information in the regridded SD Image Cube")
+            sdintlib.create_sd_psf(sdimage=output+'.residual', sdpsfname=output+'.psf')
+    
     sdintlib.deleteTmpFiles()
 
 
@@ -542,8 +559,12 @@ def sdintimaging(
         ## Init major cycle elements
         casalog.post("INT cube setup ....")
         t0=time.time();
-        imager=setup_imager(int_cube, specmode, calcres, calcpsf, bparm) 
-        mysdintlib.copy_restoringbeam(fromthis=int_cube+'.psf', tothis=int_cube+'.residual')
+        imager=setup_imager(int_cube, specmode, calcres, calcpsf, bparm)
+
+        # Copy the restoring beam from the PSF to the residual image. Only needed when setting up
+        # residual
+        if calcres:
+            mysdintlib.copy_restoringbeam(fromthis=int_cube+'.psf', tothis=int_cube+'.residual')
 
         t1=time.time();
         casalog.post("***Time for initializing imager (INT cube) : "+"%.2f"%(t1-t0)+" sec", "INFO3", "task_sdintimaging");
@@ -552,7 +573,7 @@ def sdintimaging(
         if niter>0 or restoration==True:
             casalog.post("Combined image setup ....")
             t0=time.time();
-            deconvolvertool=setup_deconvolver(decname, specmode, bparm )
+            deconvolvertool=setup_deconvolver(decname, specmode, calcpsf, calcres, bparm)
 
             t1=time.time();
             casalog.post("***Time for seting up deconvolver(s): "+"%.2f"%(t1-t0)+" sec", "INFO3", "task_sdintimaging");
@@ -560,7 +581,13 @@ def sdintimaging(
         if usedata!='int':
             ### debug (remove it later) 
             casalog.post("SD cube setup ....")
-            setup_sdimaging(template=int_cube, output=sd_cube, inparms=bparm, sdparms=sdparms ) 
+            setup_sdimaging(template=int_cube,
+                            output=sd_cube,
+                            calcpsf=calcpsf,
+                            calcres=calcres,
+                            inparms=bparm,
+                            sdparms=sdparms,
+                            )
             
 
         ####now is the time to check estimated memory
@@ -588,19 +615,30 @@ def sdintimaging(
             return
 
         #### SDINT specific feathering....
-        ## Feather INT and SD residual images (feather in flat-sky. output has common PB)
-        casalog.post("Feathering INT and SD residual images...")
-        mysdintlib.feather_residual(int_cube, sd_cube, joint_cube, applypb, inpparams)
-        mysdintlib.feather_int_sd(sdcube=sd_cube+'.psf',
-                                  intcube=int_cube+'.psf',
-                                  jointcube=joint_cube+'.psf',
-                                  sdgain=sdgain,
-                                  dishdia=dishdia,
-                                  usedata=usedata,
-                                  chanwt = inpparams['chanwt'])
 
-        #print("Fitting for cube")
-        synu.fitPsfBeam(joint_cube)
+        if calcres:
+            ## Feather INT and SD residual images (feather in flat-sky. output has common PB)
+            casalog.post("Feathering INT and SD residual images...")
+            
+            feather_residual(
+                int_cube=int_cube,
+                sd_cube=sd_cube,
+                joint_cube=joint_cube,
+                applypb=applypb,
+                inparm=inpparams,
+                mysdintlib=mysdintlib,
+            )
+        
+        if calcpsf:
+            feather_int_sd(
+                sdcube=f"{sd_cube}.psf",
+                intcube=f"{int_cube}.psf",
+                jointcube=f"{joint_cube}.psf",
+                sdgain=sdgain,
+                usedata=usedata,
+            )
+            #print("Fitting for cube")
+            synu.fitPsfBeam(joint_cube)
 
         ###############
         ##### Placeholder code for PSF renormalization if needed
@@ -614,26 +652,30 @@ def sdintimaging(
  
         if specmode=='mfs':
             ## Calculate Spectral PSFs and Taylor Residuals
-            casalog.post("Calculate spectral PSFs and Taylor Residuals...")
-            mysdintlib.cube_to_taylor_sum(cubename=joint_cube+'.psf',
-                                        cubewt=int_cube+'.sumwt',
-                                        chanwt=inpparams['chanwt'],
-                                        mtname=joint_multiterm+'.psf',
-                                        nterms=nterms, reffreq=inpparams['reffreq'], dopsf=True)
-            mysdintlib.cube_to_taylor_sum(cubename=joint_cube+'.residual',
-                                        cubewt=int_cube+'.sumwt',
-                                        chanwt=inpparams['chanwt'],
-                                        mtname=joint_multiterm+'.residual',
-                                        nterms=nterms, reffreq=inpparams['reffreq'], dopsf=False)
 
-            #print("Fit for multiterm")
-            if(deconvolver=='mtmfs' and nterms==1): # work around file naming issue
-                os.system('rm -rf '+joint_multiterm+'tmp.psf')
-                os.system('ln -sf '+joint_multiterm+'.psf.tt0 '+joint_multiterm+'tmp.psf')
-                synu.fitPsfBeam(joint_multiterm+'tmp',nterms=nterms)
-                os.system('rm -rf '+joint_multiterm+'tmp.psf')
-            else:
-                synu.fitPsfBeam(joint_multiterm,nterms=nterms)
+            if calcpsf:
+                casalog.post("Calculate spectral PSFs and Taylor Residuals...")
+                mysdintlib.cube_to_taylor_sum(cubename=joint_cube+'.psf',
+                                            cubewt=int_cube+'.sumwt',
+                                            chanwt=inpparams['chanwt'],
+                                            mtname=joint_multiterm+'.psf',
+                                            nterms=nterms, reffreq=inpparams['reffreq'], dopsf=True)
+
+                #print("Fit for multiterm")
+                if(deconvolver=='mtmfs' and nterms==1): # work around file naming issue
+                    os.system('rm -rf '+joint_multiterm+'tmp.psf')
+                    os.system('ln -sf '+joint_multiterm+'.psf.tt0 '+joint_multiterm+'tmp.psf')
+                    synu.fitPsfBeam(joint_multiterm+'tmp',nterms=nterms)
+                    os.system('rm -rf '+joint_multiterm+'tmp.psf')
+                else:
+                    synu.fitPsfBeam(joint_multiterm,nterms=nterms)
+
+            if calcres:
+                mysdintlib.cube_to_taylor_sum(cubename=joint_cube+'.residual',
+                                            cubewt=int_cube+'.sumwt',
+                                            chanwt=inpparams['chanwt'],
+                                            mtname=joint_multiterm+'.residual',
+                                            nterms=nterms, reffreq=inpparams['reffreq'], dopsf=False)
 
         if niter>0 :
             isit = deconvolvertool.hasConverged()
@@ -729,7 +771,13 @@ def sdintimaging(
                                               psfcube=sd_cube+'.psf')
 
                 ## Feather the residuals
-                mysdintlib.feather_residual(int_cube, sd_cube, joint_cube, applypb, inpparams)
+                feather_residual(
+                    int_cube=int_cube,
+                    sd_cube=sd_cube,
+                    joint_cube=joint_cube,
+                    applypb=applypb,
+                    inparm=inpparams,
+                )
                 ###############
                 ##### Placeholder code for PSF renormalization if needed
                 #mysdintlib.apply_renorm(imname=joint_cube+'.residual', sumwtname=joint_cube+'.sumwt')

--- a/phangsPipeline/taskSDIntImaging.py
+++ b/phangsPipeline/taskSDIntImaging.py
@@ -21,7 +21,7 @@ from casatasks.private.cleanhelper import write_tclean_history, get_func_params
 from casatasks.private.sdint_helper import *
 from casatools import table
 from casatasks import imstat
-from casatools import synthesisimager,synthesisutils
+from casatools import synthesisimager,synthesisutils, image
 
 from .utilsSDIntImaging import feather_int_sd, feather_residual
 
@@ -32,6 +32,49 @@ try:
 except ImportError:
     mpi_available = False
 
+
+def get_csys(im):
+    """Get RA/Dec coordsys from an image"""
+
+    ia = image()
+    ia.open(im)
+    i_csys = ia.coordsys([0, 1]).torecord()
+    ia.close()
+
+    return i_csys
+
+def check_wcs_conforms(
+        wcs1,
+        wcs2,
+):
+    """Check the important values for two csys records to see if they conform
+
+    This assumes just RA/Dec coordinates
+    """
+
+    # Things to key in on that produce singular values
+    keys_to_check = [
+        "conversionSystem",
+        "projection",
+    ]
+    for k in keys_to_check:
+        if wcs1["direction0"][k] != wcs2["direction0"][k]:
+            return False
+
+    # Things to key in on that produce arrays
+    keys_to_check = [
+        "axes",
+        "cdelt",
+        "crpix",
+        "crval",
+        "units",
+    ]
+
+    for k in keys_to_check:
+        if (wcs1["direction0"][k] != wcs2["direction0"][k]).any():
+            return False
+
+    return True
     
 # setup functions
 def setup_imagerObj(paramList=None):
@@ -103,6 +146,10 @@ def setup_imager(imagename, specmode,calcres,calpsf,inparams):
             psfimager.setWeighting()
             psfimager.makeImage('psf', psfParameters['imagename']+'.psf')
 
+    # Check PSF exists
+    if not os.path.exists(imagename + ".psf"):
+        raise FileNotFoundError(imagename + ".psf does not exist")
+
     # can take out this since niter is fixed to 0
     if locparams['niter'] >=0 :
         ## Make dirty image
@@ -143,13 +190,21 @@ def setup_deconvolver(imagename,
         #deconvolvertool.makeImage('psf', imagename+'.psf')
         deconvolvertool.makePB()  ## Make this to turn .weight into .pb maps
 
+    # Check PSF exists
+    if not os.path.exists(imagename + ".psf"):
+        raise FileNotFoundError(imagename + ".psf does not exist")
+
     ## Initialize deconvolvers. ( Order is important. This cleans up a leftover tablecache image.... FIX!)
     deconvolvertool.initializeDeconvolvers()
     deconvolvertool.initializeIterationControl() # This needs to be run before runMajorCycle
 
     if calcres:
         deconvolvertool.runMajorCycle(isCleanCycle=False) ## Make this to make template residual images.
- 
+
+    # Check residual exists
+    if not os.path.exists(imagename + ".residual"):
+        raise FileNotFoundError(imagename + ".residual does not exist")
+
     return deconvolvertool
 
 def setup_sdimaging(template='',
@@ -180,29 +235,72 @@ def setup_sdimaging(template='',
         raise RuntimeError("Internal Error: missing sdimage parameter") 
     if 'pblimit' in inparms:
         pblimit = inparms['pblimit']
-        
-    if calcres:
-        ## Regrid the input SD image to the target coordinate system.
-        sdintlib.regridimage(imagename=sdimage, template=template+'.residual', outfile=output+'.residual')
-        sdintlib.regridimage(imagename=sdimage, template=template+'.residual', outfile=output+'.image')
-    
-        ## Apply the pbmask from the INT image cube, to the SD cubes.
-        #TTB: Create *.mask cube  
-    
-        sdintlib.addmask(inpimage=output+'.residual', pbimage=template+'.pb', pblimit=pblimit)
-        sdintlib.addmask(inpimage=output+'.image', pbimage=template+'.pb', pblimit=pblimit)
 
-    if calcpsf:
-        if sdpsf != "":
-            ## check the coordinates of psf with int psf
-            sdintlib.checkpsf(sdpsf, template + ".psf")
-        if sdpsf !="":
+    # Are we regridding the SD residuals? Check if a) they exist and b) if
+    # they conform along RA/Dec, which is all the regrid actually does
+    temp_csys = get_csys(template + ".residual")
+
+    residual_exists = os.path.exists(output + '.residual')
+    residual_conforms = False
+    if residual_exists:
+        i_csys = get_csys(output + '.residual')
+        residual_conforms = check_wcs_conforms(temp_csys, i_csys)
+
+    regrid_residual = ~residual_exists | ~residual_conforms
+
+    image_exists = os.path.exists(output + '.image')
+    image_conforms = False
+    if image_exists:
+        i_csys = get_csys(output + '.image')
+        image_conforms = check_wcs_conforms(temp_csys, i_csys)
+
+    regrid_image = ~image_exists | ~image_conforms
+
+    ## Regrid the input SD image to the target coordinate system, and apply pbmask
+    if regrid_residual:
+        sdintlib.regridimage(
+            imagename=sdimage, template=template + ".residual", outfile=output + ".residual"
+        )
+        sdintlib.addmask(inpimage=output + ".residual", pbimage=template + ".pb", pblimit=pblimit)
+
+    if regrid_image:
+        sdintlib.regridimage(
+            imagename=sdimage, template=template + ".residual", outfile=output + ".image"
+        )
+        sdintlib.addmask(inpimage=output+'.image', pbimage=template+'.pb', pblimit=pblimit)
+            
+    # If we're supplying a PSF, check that it exists and is valid
+    if sdpsf != "":
+
+        if not os.path.exists(sdpsf):
+            raise FileNotFoundError(sdpsf + "does not exist")
+
+        ## check the coordinates of psf with int psf
+        sdintlib.checkpsf(sdpsf, template + ".psf")
+
+        # Check if we need to regrid
+        psf_exists = os.path.exists(output + ".psf")
+        psf_conforms = False
+        if psf_exists:
+            temp_csys = get_csys(template + ".psf")
+            i_csys = get_csys(output + ".psf")
+            psf_conforms = check_wcs_conforms(temp_csys, i_csys)
+        regrid_psf = ~psf_exists | ~psf_conforms
+
+        if regrid_psf:
             ## Regrid the input PSF cube to the target coordinate system.
             sdintlib.regridimage(imagename=sdpsf, template=template+'.psf', outfile=output+'.psf')
-        else:
-            ## Make an internal sdpsf image if the user has not supplied one.
-            casalog.post("Constructing a SD PSF cube by evaluating Gaussians based on the restoring beam information in the regridded SD Image Cube")
-            sdintlib.create_sd_psf(sdimage=output+'.residual', sdpsfname=output+'.psf')
+        
+    if calcpsf:
+        ## Make an internal sdpsf image if the user has not supplied one.
+        casalog.post(
+            "Constructing a SD PSF cube by evaluating Gaussians based on the restoring beam information in the regridded SD Image Cube"
+        )
+        sdintlib.create_sd_psf(sdimage=output + ".residual", sdpsfname=output + ".psf")
+
+    # Check PSF exists
+    if not os.path.exists(output + '.psf'):
+        raise FileNotFoundError(output + '.psf does not exist')
     
     sdintlib.deleteTmpFiles()
 
@@ -628,6 +726,10 @@ def sdintimaging(
                 inparm=inpparams,
                 mysdintlib=mysdintlib,
             )
+
+        # Check residual exists
+        if not os.path.exists(joint_cube+'.residual'):
+            raise FileNotFoundError(joint_cube + '.residual does not exist')
         
         if calcpsf:
             feather_int_sd(
@@ -639,6 +741,10 @@ def sdintimaging(
             )
             #print("Fitting for cube")
             synu.fitPsfBeam(joint_cube)
+
+        # Check PSF exists
+        if not os.path.exists(joint_cube+'.psf'):
+            raise FileNotFoundError(joint_cube + '.psf does not exist')
 
         ###############
         ##### Placeholder code for PSF renormalization if needed

--- a/phangsPipeline/utilsSDIntImaging.py
+++ b/phangsPipeline/utilsSDIntImaging.py
@@ -19,13 +19,37 @@ from .casaCubeRoutines import check_getchunk_putchunk_memory_issue
 logger = logging.getLogger(__name__)
 
 
+def check_wcs_conforms(hdr1, hdr2):
+    """Check if headers are equal in terms of celestial coordinates"""
+
+    keys_to_check = [
+        "WCSAXES",
+        "CRPIX1",
+        "CRPIX2",
+        "CDELT1",
+        "CDELT2",
+        "CUNIT1",
+        "CUNIT2",
+        "CTYPE1",
+        "CTYPE2",
+        "CRVAL1",
+        "CRVAL2",
+    ]
+
+    for k in keys_to_check:
+        if hdr1[k] != hdr2[k]:
+            return False
+
+    return True
+
+
 def feather_residual(
     int_cube: str,
     sd_cube: str,
     joint_cube: str,
     applypb: bool,
     inparm: dict,
-    mysdintlib = None,
+    mysdintlib=None,
 ):
 
     if mysdintlib is None:
@@ -106,27 +130,52 @@ def feather_int_sd(
         if int_unit == "":
             intcube_sc = intcube_sc._new_cube_with(unit=u.Jy / u.beam)
 
+        # Check to see if we need to interpolate along spectral axis
+        int_spec = intcube_sc.spectral_axis
+        sd_spec = sdcube_sc.spectral_axis
+        do_spectral_interpolate = False
+        if not len(int_spec) == len(sd_spec):
+            do_spectral_interpolate = True
+        else:
+            if not np.isclose(int_spec, sd_spec).all():
+                do_spectral_interpolate = True
+
+        # If we don't have a matching spectral axis, we'll need to interpolate
+        if do_spectral_interpolate:
+            logger.info("Reprojecting the SD cube spectrally to match INT cube")
+            sdcube_sc = sdcube_sc.spectral_interpolate(intcube_sc.spectral_axis)
+
+        # If we don't have matching RA/Dec, then we'll need to reproject
+        do_spatial_reproject = False
+        if not intcube_sc.shape[1:] == sdcube_sc.shape[1:]:
+            do_spatial_reproject = True
+        else:
+            wcs_conforms = check_wcs_conforms(
+                intcube_sc.wcs.celestial.to_header(),
+                sdcube_sc.wcs.celestial.to_header(),
+            )
+            if not wcs_conforms:
+                do_spatial_reproject = True
+
         # Ensure we have matching WCS. This has already been done in previous steps in sdintimaging,
         # so just check on the shape. If they're not the same, then we need to regrid
-        if intcube_sc.shape != sdcube_sc.shape:
-            logger.info("Reprojecting the SD cube to match the INT cube")
-            sdcube_sc = sdcube_sc.spectral_interpolate(intcube_sc.spectral_axis)
+        if do_spatial_reproject:
+            logger.info("Reprojecting the SD cube spatially to match the INT cube")
             sdcube_sc = sdcube_sc.reproject(intcube_sc.header)
 
-        # If shape is right but WCS doesn't evaluate as equal, then we need to force the WCS in
-        else:
-            is_wcs_eq = intcube_sc.wcs.wcs.compare(sdcube_sc.wcs.wcs)
-            if not is_wcs_eq:
-                # We also need to pull out and replace the mask, else it'll complain
-                if sdcube_sc._mask is not None:
-                    sdmask = BooleanArrayMask(sdcube_sc.get_mask_array(), wcs=intcube_sc.wcs)
-                else:
-                    sdmask = None
+        # If WCS doesn't evaluate as equal, then we need to force the WCS in
+        is_wcs_eq = intcube_sc.wcs.wcs.compare(sdcube_sc.wcs.wcs)
+        if not is_wcs_eq:
+            # We also need to pull out and replace the mask, else it'll complain
+            if sdcube_sc._mask is not None:
+                sdmask = BooleanArrayMask(sdcube_sc.get_mask_array(), wcs=intcube_sc.wcs)
+            else:
+                sdmask = None
 
-                sdcube_sc = sdcube_sc._new_cube_with(
-                    wcs=intcube_sc.wcs,
-                    mask=sdmask,
-                )
+            sdcube_sc = sdcube_sc._new_cube_with(
+                wcs=intcube_sc.wcs,
+                mask=sdmask,
+            )
 
         # Keep the intcube dtype around for consistency
         intcube_dtype = intcube_sc.unmasked_data[0, 0, 0].dtype

--- a/phangsPipeline/utilsSDIntImaging.py
+++ b/phangsPipeline/utilsSDIntImaging.py
@@ -1,0 +1,261 @@
+import logging
+import os
+import shutil
+
+import astropy.units as u
+import numpy as np
+from astropy.utils.console import ProgressBar
+from casatasks.private.sdint_helper import SDINT_helper
+from casatools import image
+from spectral_cube import (
+    BooleanArrayMask,
+    DaskVaryingResolutionSpectralCube,
+    SpectralCube,
+)
+from uvcombine import feather_simple, feather_simple_cube
+
+from .casaCubeRoutines import check_getchunk_putchunk_memory_issue
+
+logger = logging.getLogger(__name__)
+
+
+def feather_residual(
+    int_cube: str,
+    sd_cube: str,
+    joint_cube: str,
+    applypb: bool,
+    inparm: dict,
+    mysdintlib = None,
+):
+
+    if mysdintlib is None:
+        mysdintlib = SDINT_helper()
+
+    if applypb:
+        ## Take initial INT_dirty image to flat-sky.
+        mysdintlib.modify_with_pb(
+            inpcube=f"{int_cube}.residual",
+            pbcube=f"{int_cube}.pb",
+            cubewt=f"{int_cube}.sumwt",
+            chanwt=inparm["chanwt"],
+            action="div",
+            pblimit=inparm["pblimit"],
+            freqdep=True,
+        )
+
+    ## Feather flat-sky INT dirty image with SD image
+    feather_int_sd(
+        sdcube=f"{sd_cube}.residual",
+        intcube=f"{int_cube}.residual",
+        jointcube=f"{joint_cube}.residual",
+        sdgain=inparm["sdgain"],
+        usedata=inparm["usedata"],
+    )
+
+    if applypb:
+        if inparm["specmode"].count("cube") > 0:
+            ## Multiply the new JOINT dirty image by the frequency-dependent PB.
+            fdep_pb = True
+        else:
+            ## Multiply new JOINT dirty image by a common PB to get the effect of conjbeams.
+            fdep_pb = False
+
+        mysdintlib.modify_with_pb(
+            inpcube=f"{joint_cube}.residual",
+            pbcube=f"{int_cube}.pb",
+            cubewt=f"{int_cube}.sumwt",
+            chanwt=inparm["chanwt"],
+            action="mult",
+            pblimit=inparm["pblimit"],
+            freqdep=fdep_pb,
+        )
+
+
+def feather_int_sd(
+    sdcube: str = "",
+    intcube: str = "",
+    jointcube: str = "",
+    sdgain: float | int = 1.0,
+    usedata: str = "sdint",
+):
+    """
+    Run uvcombine to combine the SD and INT Cubes.
+    """
+
+    ### Do the feathering.
+    if usedata == "sdint":
+        # Read in the cubes. Set fill value to 0 for CASA consistency
+        sdcube_sc = SpectralCube.read(
+            sdcube,
+            format="casa",
+        )
+        sdcube_sc = sdcube_sc.with_fill_value(0.0)
+        sdcube_sc.allow_huge_operations = True
+        intcube_sc = SpectralCube.read(
+            intcube,
+            format="casa",
+        )
+        intcube_sc = intcube_sc.with_fill_value(0.0)
+        intcube_sc.allow_huge_operations = True
+
+        # If the cubes don't have units, these are Jy/beam
+        sd_unit = sdcube_sc.unit
+        int_unit = intcube_sc.unit
+        if sd_unit == "":
+            sdcube_sc = sdcube_sc._new_cube_with(unit=u.Jy / u.beam)
+        if int_unit == "":
+            intcube_sc = intcube_sc._new_cube_with(unit=u.Jy / u.beam)
+
+        # Ensure we have matching WCS. This has already been done in previous steps in sdintimaging,
+        # so just check on the shape. If they're not the same, then we need to regrid
+        if intcube_sc.shape != sdcube_sc.shape:
+            logger.info("Reprojecting the SD cube to match the INT cube")
+            sdcube_sc = sdcube_sc.spectral_interpolate(intcube_sc.spectral_axis)
+            sdcube_sc = sdcube_sc.reproject(intcube_sc.header)
+
+        # If shape is right but WCS doesn't evaluate as equal, then we need to force the WCS in
+        else:
+            is_wcs_eq = intcube_sc.wcs.wcs.compare(sdcube_sc.wcs.wcs)
+            if not is_wcs_eq:
+                # We also need to pull out and replace the mask, else it'll complain
+                if sdcube_sc._mask is not None:
+                    sdmask = BooleanArrayMask(sdcube_sc.get_mask_array(), wcs=intcube_sc.wcs)
+                else:
+                    sdmask = None
+
+                sdcube_sc = sdcube_sc._new_cube_with(
+                    wcs=intcube_sc.wcs,
+                    mask=sdmask,
+                )
+
+        # Keep the intcube dtype around for consistency
+        intcube_dtype = intcube_sc.unmasked_data[0, 0, 0].dtype
+
+        # Check if we have dask varying spectral resolution, since uvcombine cannot handle this
+        is_varying_res = any(
+            [isinstance(c, DaskVaryingResolutionSpectralCube) for c in [sdcube_sc, intcube_sc]]
+        )
+
+        logger.info("Feathering the INT and SD cubes together")
+
+        # If we do have varying resolution, we have to do this channel-by-channel
+        chans = len(intcube_sc.spectral_axis)
+        if is_varying_res:
+            feathered_cube_data = np.zeros(sdcube_sc.shape, dtype=intcube_dtype)
+
+            with ProgressBar(chans) as bar:
+                for chan in range(chans):
+                    feathered_cube_data[chan] = feather_simple(
+                        hires=intcube_sc[chan],
+                        lores=sdcube_sc[chan],
+                        lowresscalefactor=sdgain,
+                    ).real.astype(intcube_dtype)
+
+                    bar.update()
+
+        # Else just do the whole thing at once
+        else:
+            feathered_cube = feather_simple_cube(
+                cube_hi=intcube_sc,
+                cube_lo=sdcube_sc,
+                allow_huge_operations=True,
+                allow_spectral_resample=False,
+                allow_lo_reproj=False,
+                lowresscalefactor=sdgain,
+            )
+            feathered_cube_data = feathered_cube.unitless_filled_data[:].astype(intcube_dtype)
+
+        # We need to transpose the axes for CASA and add in the Stokes
+        feathered_cube_data = feathered_cube_data.T
+        feathered_cube_data = np.expand_dims(feathered_cube_data, axis=2)
+
+        # Set up the CASA images. We need to load the INT and SD images as well to get
+        # pixel masks
+        intim = image()
+        intim.open(intcube)
+
+        sdim = image()
+        sdim.open(sdcube)
+
+        if os.path.exists(jointcube):
+            shutil.rmtree(jointcube)
+        shutil.copytree(intcube, jointcube)
+
+        jointim = image()
+        jointim.open(jointcube)
+        jointim.set(0.0)  # Initialize this to zero for all planes
+
+        # Check if getchunk/putchunk will have memory issues. If so, we need to do this channel by channel
+        has_memory_issue = check_getchunk_putchunk_memory_issue(
+            jointcube,
+            myia=jointim,
+        )
+
+        # We respect dtypes around here
+        jointim_dtype = jointim.pixeltype()
+
+        if has_memory_issue:
+            logger.info("Writing out feathered cube channel-by-channel due to memory issue")
+
+            nx = feathered_cube_data.shape[0]
+            ny = feathered_cube_data.shape[1]
+
+            blc = [0, 0, 0, 0]
+            trc = [nx - 1, ny - 1, 0, 0]
+
+            with ProgressBar(chans) as bar:
+                for chan in range(chans):
+                    # Channel is the last axis of the cube, so update blc/trc
+                    blc[-1] = chan
+                    trc[-1] = chan
+
+                    # Create mask, apply to channel slice.
+                    int_mask = intim.getchunk(blc=blc, trc=trc, getmask=True)
+                    sd_mask = sdim.getchunk(blc=blc, trc=trc, getmask=True)
+
+                    # Slice out the channel axis
+                    int_mask = int_mask[:, :, :, 0]
+                    sd_mask = sd_mask[:, :, :, 0]
+
+                    mask = int_mask & sd_mask
+
+                    feathered_cube_slice = feathered_cube_data[:, :, :, chan]
+
+                    feathered_cube_slice[~mask] = 0.0
+
+                    jointim.putchunk(
+                        feathered_cube_slice.astype(jointim_dtype),
+                        blc=blc,
+                    )
+
+                    bar.update()
+
+        else:
+            logger.info("Writing out feathered cube to CASA image")
+
+            # Combine the INT/SD masks
+            int_mask = intim.getchunk(getmask=True)
+            sd_mask = sdim.getchunk(getmask=True)
+            mask = int_mask & sd_mask
+
+            # Make sure everything outside the mask is set to zero, since CASA expects this
+            feathered_cube_data[~mask] = 0.0
+
+            # Write this out back into the CASA image
+            jointim.putchunk(feathered_cube_data.astype(jointim_dtype))
+
+        # Close out the images, and we're done!
+        intim.close()
+        sdim.close()
+        jointim.close()
+
+    elif usedata == "sd":
+        if os.path.exists(jointcube):
+            shutil.rmtree(jointcube)
+        shutil.copytree(sdcube, jointcube)
+    elif usedata == "int":
+        if os.path.exists(jointcube):
+            shutil.rmtree(jointcube)
+        shutil.copytree(intcube, jointcube)
+    else:
+        raise ValueError("usedata should be one of sdint, sd, or int")


### PR DESCRIPTION
This PR adds significant speedups to sdintimaging in two ways:

- First, and easiest, by making sure that various PSF/PB steps are only carried out the first time. These are slow since they often run major cycles, and only need to be done once to generate cubes, so this has now been fixed.
- Second, because ``feather`` forces a regrid under-the-hood, and this is slow, we now use a smarter uvcombine implementation which doesn't necessarily require regridding (but will if absolutely needed).

Two test cases here, the first is a noise-only 10-channel chunk for NGC5236_1, 7m+TP. This should be the more fair test since you might expect recovering the additional flux that sdintimaging gets would take longer. Timings:

- ``tclean``: 649s
- Old ``sdintimaging``: 1953s
- New ``sdintimaging``: 947s

Second test case here was a signal-filled 10-channel chunk for NGC5236_1, 7m+TP. Timings:

- ``tclean``: 1682s
- Old ``sdintimaging``: 5898s
- New ``sdintimaging``: 2191s

Note these are all run on the same machine. So we're about 1.5x slower than tclean, but 2x faster than the previous sdintimaging implementation, and perhaps a little better in the case with emission. Hooray! I think these are lower bounds as well, as I'd expect for larger cubes the gains should be bigger since these parts often become the bottleneck.

Comparing the signal-filled cubes they're extremely similar. Blue shows 1/50/99th percentiles of the (new implementation) data. The black is the difference, with 1/99th percentiles as the shaded region. The differences here I think are mostly due uvcombine vs feather and the fact that we technically now run fewer major cycles, rather than anything particularly deep. The differences are generally pretty small, and the median diff is locked at 0. The cubes look identical by-eye, structure is the same.

<img width="708" height="371" alt="sdint_comparison" src="https://github.com/user-attachments/assets/145fd874-a71c-4b69-92f3-2e0531b8a92b" />

Also tagging Remy in here, since I think a good chunk of this would be good to feed back into the actual task

Changes:

- In ``setup_deconvolver``, only run ``makePSF``/``makePB`` if calcpsf=True
- In ``setup_deconvolver``, only run a major cycle to make template residual images if calcres=True
- In ``setup_sdimaging``, only generate SD residual/image if calcres=True
- In ``setup_sdimaging``, only create the SD PSF if calcpsf=True
- In main code, only copy restoring beam to residual image if calcres=True
- In main code, only do the initial feather if calcres=True
- In main code, only feather INT/SD PSF and fitPsfBeam if calcpsf=True
- In main code, only do ``cube_to_taylor_sum`` for the PSF if calcpsf=True
- In main code, only do initial ``cube_to_taylor_sum`` for residuals if calcres=True
- Swap out feather for uvcombine
- Use uvcombine replacements for ``feather_residual`` and ``feather_int_sd``, which live inside the new utilsSDIntImaging.py
- Add uvcombine to pyproject.toml
