### PR TITLE
Two small fixes in spectral-cube postprocessing (trim_cube and mosaic files)

### DIFF
--- a/phangsPipeline/handlerPostprocess.py
+++ b/phangsPipeline/handlerPostprocess.py
@@ -1113,6 +1113,23 @@ if casa_enabled:
                     os.system('rm -rf %s' % new_file_name)
                     os.system(command)
 
+                # Rename the image_slice mosaic files
+                slice_file = outdir + item + "_slice.txt"
+                if os.path.exists(slice_file):
+                    new_slice_file = outdir + fname_dict_out[key] + "_slice.txt"
+                    os.system('rm -f %s' % new_slice_file)
+                    os.system('mv -f %s %s' % (slice_file, new_slice_file))
+
+            # Rename the linear mosaic template headers
+            for template_suffix in ["flux", "weight", "mask"]:
+                template_in = outdir + "%s_%s_%s_linmos_template_%s.txt" % (
+                    target, config, product, template_suffix)
+                template_out = outdir + "%s_%s_%s_linmos_template_%s.txt" % (
+                    target, feather_config, product, template_suffix)
+                if os.path.exists(template_in):
+                    os.system('rm -f %s' % template_out)
+                    os.system('mv -f %s %s' % (template_in, template_out))
+
             return
 
         def task_compress(

--- a/phangsPipeline/scCubeRoutines.py
+++ b/phangsPipeline/scCubeRoutines.py
@@ -714,7 +714,7 @@ def trim_cube(
         )
         i_min = np.max([0, np.min(np.where(mask_spec_i)) - pad])
         i_max = np.min([np.max(np.where(mask_spec_i)) + pad, mask.shape[ax] - 1])
-        axis_slices.append(slice(i_min, i_max))
+        axis_slices.append(slice(i_min, i_max + 1))
 
     # Slice down the cube
     cube = cube[*axis_slices]


### PR DESCRIPTION
1. `trim_cube` off-by-one error drops the final slice in `scCubeRoutines.py` (inclusive vs. exclusive stop). This runs once for prep and once for cleanup, so compounds in the postprocessing stage. 

2. Mosaic text files aren't renamed under the stdintimaging branch (`task_rename_sdintimaging` in 
`handlerPostprocess.py`) to include "tp" (e.g., "12m+7m" -> "12m+7m+tp") and are stranded.  This matters if the mosaic stage is rerun, which would otherwise fail to find the files. 