### PR TITLE
Skip feather-config mosaic pass when nothing was feathered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed crash if spectral/Stokes axis is swapped when making large mosaics (#366).
 - Keep tests running on test matrix even if one fails (#379).
 - Fixed typing on key import (#380).
+- Skip the feather-config mosaic pass when nothing was feathered (#383).
 
 ### Dependencies
 - Bump actions/upload-artifact from 6 to 7 (#313).

--- a/phangsPipeline/handlerPostprocess.py
+++ b/phangsPipeline/handlerPostprocess.py
@@ -1993,8 +1993,8 @@ if casa_enabled:
                         continue
 
                     # Skip if we're not feathering before mosaic
-                    if do_feather and not feather_before_mosaic:
-                        logger.debug("Skipping " + this_target + " because feather_before_mosaic is False.")
+                    if not (do_feather and feather_before_mosaic):
+                        logger.debug("Skipping " + this_target + " because feather products were not made before mosaicking.")
                         continue
 
                     if feather_apod:


### PR DESCRIPTION
Under `imaging_method="sdintimaging"` with `do_feather=False`, this avoids the harmless but scary `[ERROR]: No files to process` outputs and several `Missing file` warnings. 